### PR TITLE
fix: minor fixes

### DIFF
--- a/package/components/editor-toolbar.tsx
+++ b/package/components/editor-toolbar.tsx
@@ -244,10 +244,12 @@ const TiptapToolBar = ({
             primaryAction={{
               label: 'Export',
               onClick: handleExport,
+              className: "w-full md:w-auto",
             }}
             secondaryAction={{
               label: 'Cancel',
               onClick: () => setIsExportModalOpen(false),
+              className: "w-full md:w-auto",
             }}
           />
         </div>

--- a/package/extensions/default-extension.ts
+++ b/package/extensions/default-extension.ts
@@ -172,7 +172,7 @@ export const defaultExtensions = [
   ColumnExtension,
   MarkdownPasteHandler,
   Markdown.configure({
-    html: true, // Allow HTML input/output
+    html: false, // Allow HTML input/output
     tightLists: true, // No <p> inside <li> in markdown output
     tightListClass: 'tight', // Add class to <ul> allowing you to remove <p> margins when tight
     bulletListMarker: '-', // <li> prefix in markdown output

--- a/package/extensions/mardown-paste-handler/index.ts
+++ b/package/extensions/mardown-paste-handler/index.ts
@@ -93,7 +93,7 @@ turndownService.addRule('iframe', {
   filter: ['iframe'],
   replacement: function (_content, node) {
     const src = (node as HTMLElement).getAttribute('src');
-    return src ? `[iframe](${src})` : '';
+    return src ? `[${src}](${src})` : '';
   },
 });
 
@@ -102,7 +102,7 @@ turndownService.addRule('img', {
   filter: ['img'],
   replacement: function (_content, node) {
     const src = (node as HTMLElement).getAttribute('src');
-    const alt = (node as HTMLElement).getAttribute('alt') || 'image';
+    const alt = (node as HTMLElement).getAttribute('alt') || src;
 
     if (src?.startsWith('data:')) {
       return src;


### PR DESCRIPTION
- meaningful turndown rules for iframe/image link exports
- update styling for export modal buttons on mobile
- fixed copy editor content as markdown and be able to paste back to remain original