### PR TITLE
fix: topbar cover up content

### DIFF
--- a/package/components/editor-utils.tsx
+++ b/package/components/editor-utils.tsx
@@ -906,6 +906,16 @@ export const TextFormatingPopup = ({
       },
       isActive: () => editor.isActive('heading', { level: 3 }),
     },
+    {
+      title: 'Code',
+      description: 'Code block',
+      icon: <Braces size={20} />,
+      command: (editor: Editor) => {
+        editor.chain().toggleCodeBlock().run();
+      },
+      isActive: () => editor.isActive('codeBlock'),
+    },
+
   ];
 
   useOnClickOutside(popupRef, () => setToolVisibility(IEditorTool.NONE));
@@ -1099,21 +1109,6 @@ export const TextFormatingPopup = ({
               </button>
             </div>
             <div className="bg-[#f8f9fa] rounded flex flex-[0.5] sm:flex-none gap-2 justify-evenly w-full sm:w-fit p-1">
-              <button
-                onClick={() => {
-                  editor?.chain().toggleCodeBlock().run();
-                }}
-                className={cn(
-                  'flex items-center space-x-2 rounded px-4 py-1 text-black transition h-9',
-                  {
-                    ['bg-yellow-300 hover:brightness-90']:
-                      editor.isActive('codeBlock'),
-                    ['hover:bg-[#f2f2f2]']: !editor.isActive('codeBlock'),
-                  },
-                )}
-              >
-                <Braces size={20} />
-              </button>
               <button
                 onClick={() => {
                   editor?.chain().toggleBulletList().run();

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -167,7 +167,7 @@ const DdocEditor = forwardRef(
         {isNavbarVisible && (
           <nav
             id="Navbar"
-            className="h-14 bg-[#ffffff] py-2 px-3 xl:px-4 flex gap-[40px] items-center justify-between w-screen xl:w-full sticky left-0 top-0 border-b color-border-default"
+            className="h-14 bg-[#ffffff] py-2 px-3 xl:px-4 flex gap-[40px] items-center justify-between w-screen xl:w-full fixed left-0 top-0 border-b color-border-default z-50"
           >
             {renderNavbar?.({ editor: editor.getJSON() })}
           </nav>
@@ -176,7 +176,7 @@ const DdocEditor = forwardRef(
           <div
             id="toolbar"
             className={cn(
-              'z-50 hidden xl:flex items-center justify-center w-full h-[52px] sticky left-0 px-1 bg-[#ffffff]',
+              'z-50 hidden xl:flex items-center justify-center w-full h-[52px] fixed left-0 px-1 bg-[#ffffff]',
               { 'top-14': isNavbarVisible, 'top-0': !isNavbarVisible },
             )}
           >
@@ -192,8 +192,10 @@ const DdocEditor = forwardRef(
         )}
         <div
           className={cn(
-            'p-4 md:px-[80px] xl:mt-6 md:py-[78px] bg-white w-full md:w-[850px] max-w-[850px] mx-auto',
+            'p-4 md:px-[80px] md:mt-12 md:py-[78px] bg-white w-full md:w-[850px] max-w-[850px] mx-auto',
             { 'mt-0 xl:!mt-6': isPreviewMode },
+            { 'pt-20': isNavbarVisible },
+            { 'pt-6': !isNavbarVisible },
           )}
           style={{
             height:


### PR DESCRIPTION
- [x] Fixed content covered up, messed up by topbar on mobile when embed new template
- [x] Rearranged code block on utils bottom drawer