### PR TITLE
docs: update style path per exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repo contains example - demo source code and package code
 
 `import { DdocEditor } from '@fileverse-dev/ddoc'`
 
-`import '@fileverse-dev/ddoc/dist/style.css'` in App.jsx/App.tsx
+`import '@fileverse-dev/ddoc/styles'` in App.jsx/App.tsx
 
 In your tailwind config, add this line to content array
 


### PR DESCRIPTION
per title 
from package.json, seems import `/styles` works but not `dist/style.css`
```
  "exports": {
    ".": {
      "import": "./dist/index.es.js",
      "types": "./dist/index.d.ts"
    },
    "./styles": "./dist/style.css",
    "./types": "./dist/package/types.d.ts"
  },
```

