### PR TITLE
Upload image improvements

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -121,7 +121,7 @@ function App() {
         }}
         renderNavbar={renderNavbar}
         ensResolutionUrl={import.meta.env.ENS_RESOLUTION_URL}
-        secureImageUploadUrl={import.meta.env.SECURE_IMAGE_UPLOAD_URL}
+        secureImageUploadUrl={import.meta.env.VITE_SECURE_IMAGE_UPLOAD_URL}
         tags={sampleTags}
         selectedTags={selectedTags}
         setSelectedTags={setSelectedTags}

--- a/package/components/editor-utils.tsx
+++ b/package/components/editor-utils.tsx
@@ -120,10 +120,10 @@ export const fonts = [
   },
 ];
 
-export const MAX_IMAGE_SIZE = 1024 * 100; // 100Kb
+export const MAX_IMAGE_SIZE = 1024 * 1024 * 10; // 10MB
 
 export const ERR_MSG_MAP = {
-  IMAGE_SIZE: 'Image size should be less than 100KB',
+  IMAGE_SIZE: 'Image size should be less than 10MB',
 };
 
 export const useEditorToolbar = ({
@@ -399,7 +399,7 @@ export const useEditorToolbar = ({
               return;
             }
             const pos = editor.view.state.selection.from;
-            startImageUpload(file, editor.view, pos);
+            startImageUpload(file, editor.view, pos, secureImageUploadUrl);
           }
         };
         input.click();

--- a/package/components/slash-comand.tsx
+++ b/package/components/slash-comand.tsx
@@ -64,9 +64,11 @@ const Command = Extension.create({
 const getSuggestionItems = ({
   query,
   onError,
+  secureImageUploadUrl,
 }: {
   query: string;
   onError?: (errorString: string) => void;
+  secureImageUploadUrl?: string;
 }) => {
   return [
     {
@@ -230,7 +232,7 @@ const getSuggestionItems = ({
               return;
             }
             const pos = editor.view.state.selection.from;
-            startImageUpload(file, editor.view, pos);
+            startImageUpload(file, editor.view, pos, secureImageUploadUrl);
           }
         };
         input.click();
@@ -482,9 +484,9 @@ const renderItems = () => {
   };
 };
 
-const SlashCommand = (onError?: (errorString: string) => void) => {
+const SlashCommand = (onError?: (errorString: string) => void, secureImageUploadUrl?: string) => {
   const items = ({ query }: { query: string }) => {
-    return getSuggestionItems({ query, onError });
+    return getSuggestionItems({ query, onError, secureImageUploadUrl });
   };
   return Command.configure({
     suggestion: {

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -83,6 +83,7 @@ const DdocEditor = forwardRef(
       onError,
       setCharacterCount,
       setWordCount,
+      secureImageUploadUrl
     });
 
     useImperativeHandle(

--- a/package/extensions/d-block/dblock-node-view.tsx
+++ b/package/extensions/d-block/dblock-node-view.tsx
@@ -23,12 +23,14 @@ import {
   renderTemplateButtons,
 } from '../../utils/template-utils';
 import { LucideIcon } from '@fileverse/ui';
+// import { startImageUpload } from '../../utils/upload-images';
 
-export const DBlockNodeView: React.FC<NodeViewProps> = ({
+export const DBlockNodeView: React.FC<NodeViewProps & { secureImageUploadUrl?: string }> = ({
   node,
   getPos,
   editor,
   deleteNode,
+  secureImageUploadUrl,
 }) => {
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
   const actions = useContentItemActions(editor as Editor, node, getPos());
@@ -117,7 +119,7 @@ export const DBlockNodeView: React.FC<NodeViewProps> = ({
     }
   };
 
-  const setMedia = (type: 'img' | 'iframe', src: string) => {
+  const setMedia = (type: 'img' | 'iframe' | 'secure-img', src: string) => {
     const pos = getPos();
     const to = pos + node.nodeSize;
 
@@ -128,6 +130,12 @@ export const DBlockNodeView: React.FC<NodeViewProps> = ({
         .deleteRange({ from: pos === 0 ? pos : pos + 1, to })
         .setMedia({ src, 'media-type': 'img' })
         .run();
+    } else if (type === 'secure-img') {
+      // Convert base64 to File object
+      console.log('secureImageUploadUrl', secureImageUploadUrl);
+
+      // Use startImageUpload function
+      // startImageUpload(file, editor.view, pos, secureImageUploadUrl);
     } else {
       editor
         ?.chain()
@@ -302,9 +310,8 @@ export const DBlockNodeView: React.FC<NodeViewProps> = ({
           }
         >
           <div
-            className={`d-block-button cursor-pointer ${
-              !isPreviewMode && 'group-hover:opacity-100'
-            }`}
+            className={`d-block-button cursor-pointer ${!isPreviewMode && 'group-hover:opacity-100'
+              }`}
             contentEditable={false}
             onClick={handleClick}
           >
@@ -318,9 +325,8 @@ export const DBlockNodeView: React.FC<NodeViewProps> = ({
           <Popover.Root open={menuOpen} onOpenChange={setMenuOpen}>
             <Popover.Trigger asChild>
               <div
-                className={`d-block-button cursor-pointer ${
-                  !isPreviewMode && 'group-hover:opacity-100'
-                }`}
+                className={`d-block-button cursor-pointer ${!isPreviewMode && 'group-hover:opacity-100'
+                  }`}
                 contentEditable={false}
                 draggable
                 data-drag-handle

--- a/package/extensions/d-block/dblock.ts
+++ b/package/extensions/d-block/dblock.ts
@@ -4,6 +4,7 @@ import { ReactNodeViewRenderer } from '@tiptap/react';
 import { DBlockNodeView } from './dblock-node-view';
 export interface DBlockOptions {
   HTMLAttributes: Record<string, any>;
+  secureImageUploadUrl?: string;
 }
 
 declare module '@tiptap/core' {
@@ -32,6 +33,7 @@ export const DBlock = Node.create<DBlockOptions>({
   addOptions() {
     return {
       HTMLAttributes: {},
+      secureImageUploadUrl: '',
     };
   },
 
@@ -329,6 +331,6 @@ export const DBlock = Node.create<DBlockOptions>({
   },
 
   addNodeView() {
-    return ReactNodeViewRenderer(DBlockNodeView);
+    return ReactNodeViewRenderer(DBlockNodeView as any);
   },
 });

--- a/package/extensions/default-extension.ts
+++ b/package/extensions/default-extension.ts
@@ -40,7 +40,7 @@ import Subscript from '@tiptap/extension-subscript';
 import { ResizableMedia } from './resizable-media';
 import { uploadFn } from '../utils/upload-images';
 
-export const defaultExtensions = (onError: (error: string) => void) => [
+export const defaultExtensions = (onError: (error: string) => void, secureImageUploadUrl?: string) => [
   FontFamily,
   StarterKit.configure({
     strike: {
@@ -162,6 +162,7 @@ export const defaultExtensions = (onError: (error: string) => void) => [
   ResizableMedia.configure({
     uploadFn: uploadFn,
     onError: onError,
+    secureImageUploadUrl
   }),
   GapCursor,
   DBlock,

--- a/package/extensions/default-extension.ts
+++ b/package/extensions/default-extension.ts
@@ -40,7 +40,10 @@ import Subscript from '@tiptap/extension-subscript';
 import { ResizableMedia } from './resizable-media';
 import { uploadFn } from '../utils/upload-images';
 
-export const defaultExtensions = (onError: (error: string) => void, secureImageUploadUrl?: string) => [
+export const defaultExtensions = (
+  onError: (error: string) => void,
+  secureImageUploadUrl?: string,
+) => [
   FontFamily,
   StarterKit.configure({
     strike: {
@@ -117,7 +120,7 @@ export const defaultExtensions = (onError: (error: string) => void, secureImageU
         'color-text-link font-bold transition-colors cursor-pointer select-text pointer-events-auto',
       rel: 'noopener noreferrer',
     },
-    validate: (href) => /^https?:\/\//.test(href),
+    validate: href => /^https?:\/\//.test(href),
     openOnClick: true,
     autolink: true,
   }),
@@ -162,10 +165,12 @@ export const defaultExtensions = (onError: (error: string) => void, secureImageU
   ResizableMedia.configure({
     uploadFn: uploadFn,
     onError: onError,
-    secureImageUploadUrl
+    secureImageUploadUrl,
   }),
   GapCursor,
-  DBlock,
+  DBlock.configure({
+    secureImageUploadUrl,
+  }),
   TrailingNode,
   Document,
   ...SuperchargedTableExtensions,

--- a/package/extensions/resizable-media/media-paste-drop-plugin/media-paste-drop-plugin.ts
+++ b/package/extensions/resizable-media/media-paste-drop-plugin/media-paste-drop-plugin.ts
@@ -1,5 +1,6 @@
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { ERR_MSG_MAP, MAX_IMAGE_SIZE } from '../../../components/editor-utils';
+import {startImageUpload} from "../../../utils/upload-images.tsx";
 
 export type UploadFnType = (image: File) => Promise<string>;
 
@@ -14,6 +15,7 @@ export type UploadFnType = (image: File) => Promise<string>;
 export const getMediaPasteDropPlugin = (
   upload: UploadFnType,
   onError: (error: string) => void,
+  secureImageUploadUrl?: string
 ) => {
   return new Plugin({
     key: new PluginKey('media-paste-drop'),
@@ -75,16 +77,7 @@ export const getMediaPasteDropPlugin = (
 
           if (upload) {
             try {
-              const uploadedSrc = await upload(imageOrVideo);
-              const node = schema.nodes.resizableMedia.create({
-                src: uploadedSrc,
-                'media-type': imageOrVideo.type.includes('image')
-                  ? 'img'
-                  : 'video',
-              });
-
-              const transaction = view.state.tr.insert(coordinates.pos, node);
-              view.dispatch(transaction);
+              startImageUpload(imageOrVideo, view, coordinates.pos, secureImageUploadUrl);
             } catch (error) {
               onError((error as Error).message || 'Error uploading media');
               throw new Error(

--- a/package/extensions/resizable-media/media-paste-drop-plugin/media-paste-drop-plugin.ts
+++ b/package/extensions/resizable-media/media-paste-drop-plugin/media-paste-drop-plugin.ts
@@ -22,6 +22,21 @@ export const getMediaPasteDropPlugin = (
     props: {
       handlePaste(_view, event) {
         const items = Array.from(event.clipboardData?.items || []);
+        const files = event.clipboardData?.files;
+        const position = _view.state.selection.from;
+
+        if (!position) {
+          return false;
+        }
+
+        Object.values(files).forEach(file => {
+          const isImage = file?.type.indexOf('image') === 0;
+
+          if (isImage) {
+            startImageUpload(file, _view, position, secureImageUploadUrl);
+          }
+        })
+
 
         items.forEach(item => {
           const file = item.getAsFile();

--- a/package/extensions/resizable-media/media-paste-drop-plugin/media-paste-drop-plugin.ts
+++ b/package/extensions/resizable-media/media-paste-drop-plugin/media-paste-drop-plugin.ts
@@ -1,6 +1,6 @@
 import { Plugin, PluginKey } from 'prosemirror-state';
 import { ERR_MSG_MAP, MAX_IMAGE_SIZE } from '../../../components/editor-utils';
-import {startImageUpload} from "../../../utils/upload-images.tsx";
+import { startImageUpload } from '../../../utils/upload-images.tsx';
 
 export type UploadFnType = (image: File) => Promise<string>;
 
@@ -15,7 +15,7 @@ export type UploadFnType = (image: File) => Promise<string>;
 export const getMediaPasteDropPlugin = (
   upload: UploadFnType,
   onError: (error: string) => void,
-  secureImageUploadUrl?: string
+  secureImageUploadUrl?: string,
 ) => {
   return new Plugin({
     key: new PluginKey('media-paste-drop'),
@@ -29,15 +29,15 @@ export const getMediaPasteDropPlugin = (
           return false;
         }
 
-        Object.values(files).forEach(file => {
+        Object.values(files ?? {}).forEach(file => {
           const isImage = file?.type.indexOf('image') === 0;
 
           if (isImage) {
             startImageUpload(file, _view, position, secureImageUploadUrl);
           }
-        })
+        });
 
-
+        // TODO: Check if the gif is supported and without duplicated images
         items.forEach(item => {
           const file = item.getAsFile();
 
@@ -90,9 +90,14 @@ export const getMediaPasteDropPlugin = (
         imagesAndVideos.forEach(async imageOrVideo => {
           const reader = new FileReader();
 
-          if (upload) {
+          if (typeof upload === 'function') {
             try {
-              startImageUpload(imageOrVideo, view, coordinates.pos, secureImageUploadUrl);
+              startImageUpload(
+                imageOrVideo,
+                view,
+                coordinates.pos,
+                secureImageUploadUrl,
+              );
             } catch (error) {
               onError((error as Error).message || 'Error uploading media');
               throw new Error(

--- a/package/extensions/resizable-media/media-paste-drop-plugin/media-paste-drop-plugin.ts
+++ b/package/extensions/resizable-media/media-paste-drop-plugin/media-paste-drop-plugin.ts
@@ -29,13 +29,19 @@ export const getMediaPasteDropPlugin = (
           return false;
         }
 
-        Object.values(files ?? {}).forEach(file => {
-          const isImage = file?.type.indexOf('image') === 0;
+        const filesContainImage = Object.values(files ?? {}).some(file => file?.type.indexOf('image') === 0);
 
-          if (isImage) {
-            startImageUpload(file, _view, position, secureImageUploadUrl);
-          }
-        });
+        if (filesContainImage) {
+          Object.values(files ?? {}).forEach(file => {
+            const isImage = file?.type.indexOf('image') === 0;
+
+            if (isImage) {
+              startImageUpload(file, _view, position, secureImageUploadUrl);
+            }
+          });
+
+          return true;
+        }
 
         // TODO: Check if the gif is supported and without duplicated images
         items.forEach(item => {

--- a/package/extensions/resizable-media/resizable-media.ts
+++ b/package/extensions/resizable-media/resizable-media.ts
@@ -32,6 +32,7 @@ export interface MediaOptions {
   HTMLAttributes: Record<string, any>;
   uploadFn: UploadFnType;
   onError: (error: string) => void;
+  secureImageUploadUrl?: string;
 }
 
 export const IMAGE_INPUT_REGEX =
@@ -54,6 +55,7 @@ export const ResizableMedia = Node.create<MediaOptions>({
       onError: () => {
         console.error('Error uploading media');
       },
+      secureImageUploadUrl: ''
     };
   },
 
@@ -255,7 +257,7 @@ export const ResizableMedia = Node.create<MediaOptions>({
 
   addProseMirrorPlugins() {
     return [
-      getMediaPasteDropPlugin(this.options.uploadFn, this.options.onError),
+      getMediaPasteDropPlugin(this.options.uploadFn, this.options.onError, this.options.secureImageUploadUrl),
       UploadImagesPlugin(),
     ];
   },

--- a/package/extensions/resizable-media/resizable-media.ts
+++ b/package/extensions/resizable-media/resizable-media.ts
@@ -47,7 +47,7 @@ export const ResizableMedia = Node.create<MediaOptions>({
   addOptions() {
     return {
       HTMLAttributes: {
-        class: 'rounded-lg border border-stone-200',
+        class: 'rounded-lg border color-border-default',
       },
       uploadFn: async () => {
         return '';
@@ -55,7 +55,7 @@ export const ResizableMedia = Node.create<MediaOptions>({
       onError: () => {
         console.error('Error uploading media');
       },
-      secureImageUploadUrl: ''
+      secureImageUploadUrl: '',
     };
   },
 
@@ -102,7 +102,7 @@ export const ResizableMedia = Node.create<MediaOptions>({
       },
       privateKey: {
         default: null,
-      }
+      },
     };
   },
 
@@ -257,7 +257,11 @@ export const ResizableMedia = Node.create<MediaOptions>({
 
   addProseMirrorPlugins() {
     return [
-      getMediaPasteDropPlugin(this.options.uploadFn, this.options.onError, this.options.secureImageUploadUrl),
+      getMediaPasteDropPlugin(
+        this.options.uploadFn,
+        this.options.onError,
+        this.options.secureImageUploadUrl,
+      ),
       UploadImagesPlugin(),
     ];
   },

--- a/package/use-ddoc-editor.tsx
+++ b/package/use-ddoc-editor.tsx
@@ -46,7 +46,7 @@ export const useDdocEditor = ({
   const [ydoc] = useState(new Y.Doc());
   const [extensions, setExtensions] = useState([
     ...(defaultExtensions((error: string) => onError?.(error), secureImageUploadUrl) as AnyExtension[]),
-    SlashCommand((error: string) => onError?.(error)),
+    SlashCommand((error: string) => onError?.(error), secureImageUploadUrl),
     customTextInputRules,
   ]);
   const initialContentSetRef = useRef(false);

--- a/package/use-ddoc-editor.tsx
+++ b/package/use-ddoc-editor.tsx
@@ -41,10 +41,11 @@ export const useDdocEditor = ({
   onError,
   setCharacterCount,
   setWordCount,
+  secureImageUploadUrl
 }: Partial<DdocProps>) => {
   const [ydoc] = useState(new Y.Doc());
   const [extensions, setExtensions] = useState([
-    ...(defaultExtensions((error: string) => onError?.(error)) as AnyExtension[]),
+    ...(defaultExtensions((error: string) => onError?.(error), secureImageUploadUrl) as AnyExtension[]),
     SlashCommand((error: string) => onError?.(error)),
     customTextInputRules,
   ]);

--- a/package/utils/upload-images.tsx
+++ b/package/utils/upload-images.tsx
@@ -32,7 +32,7 @@ const UploadImagesPlugin = () =>
           const placeholder = document.createElement('div');
           placeholder.setAttribute('class', 'img-placeholder');
           const image = document.createElement('img');
-          image.setAttribute('class', 'rounded-lg border border-stone-200');
+          image.setAttribute('class', 'bg-white z-50 object-contain');
           image.src = src;
           placeholder.appendChild(image);
           const deco = Decoration.widget(pos + 1, placeholder, {
@@ -84,19 +84,19 @@ export async function startImageUpload(file: File, view: EditorView, pos: number
     tr.setMeta(uploadKey, {
       add: {
         id,
-        pos,
+        pos: pos - 1,
         src: imagePlaceholder,
       },
     });
     view.dispatch(tr);
 
-    const {schema} = view.state;
+    const { schema } = view.state;
     const placeholder = findPlaceholder(view.state, id);
     if (!placeholder) return;
 
     if (secureImageUploadUrl) {
-      const {publicKey, privateKey} = await generateRSAKeyPair();
-      const {key, url, iv} = await uploadSecureImage(secureImageUploadUrl, file, publicKey);
+      const { publicKey, privateKey } = await generateRSAKeyPair();
+      const { key, url, iv } = await uploadSecureImage(secureImageUploadUrl, file, publicKey);
 
       const node = schema.nodes.resizableMedia.create({
         encryptedKey: key,
@@ -108,13 +108,13 @@ export async function startImageUpload(file: File, view: EditorView, pos: number
 
       const transaction = view.state.tr
         .replaceWith(pos - 2, pos + node.nodeSize, node)
-        .setMeta(uploadKey, {remove: {id}});
+        .setMeta(uploadKey, { remove: { id } });
       view.dispatch(transaction);
     } else {
       const fileReader = new FileReader();
       fileReader.readAsDataURL(file);
       fileReader.onloadend = () => {
-        const {schema} = view.state;
+        const { schema } = view.state;
         const pos = findPlaceholder(view.state, id);
         if (!pos) return;
         const src = fileReader.result as string;
@@ -124,7 +124,7 @@ export async function startImageUpload(file: File, view: EditorView, pos: number
         });
         const transaction = view.state.tr
           .replaceWith(pos - 2, pos + node.nodeSize, node)
-          .setMeta(uploadKey, {remove: {id}});
+          .setMeta(uploadKey, { remove: { id } });
         view.dispatch(transaction);
       }
     }


### PR DESCRIPTION
we should take care of these other scenarios of uploading images:

- copy-to-clipboard handler for Copy Image - it can be referenced from  handlePaste in media-paste-drop-plugin.ts
- and Copy Image Address - can be referenced from mediaRender in dblock-node-view.tsx
- and Drag-n-drop images from local to the editor via handleDrop in media-paste-drop-plugin.ts