### PR TITLE
feat: upgrade common mark regex for sub/superscripts

### DIFF
--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -322,7 +322,7 @@ const DdocEditor = forwardRef(
               <EditorContent
                 editor={editor}
                 id="editor"
-                className="w-full h-full py-4"
+                className="w-full h-auto py-4"
               />
             </EditingProvider>
           </div>

--- a/package/extensions/mardown-paste-handler/index.ts
+++ b/package/extensions/mardown-paste-handler/index.ts
@@ -272,12 +272,12 @@ const MarkdownPasteHandler = Extension.create({
         },
       }),
       new InputRule({
-        find: /\^(.*?)\^/,
+        find: /(\S*)\^((?:[^\^]|\\\^)+)\^/,
         handler: ({ state, range, match }) => {
           const { tr } = state;
-          const start = range.from;
+          const start = range.from + match[1].length;
           const end = range.to;
-          const content = match[1];
+          const content = match[2].replace(/\\\^/g, '^');
           tr.replaceWith(
             start,
             end,
@@ -288,12 +288,12 @@ const MarkdownPasteHandler = Extension.create({
         },
       }),
       new InputRule({
-        find: /~(.*?)~/,
+        find: /(\S*)~((?:[^~]|\\~)+)~/,
         handler: ({ state, range, match }) => {
           const { tr } = state;
-          const start = range.from;
+          const start = range.from + match[1].length;
           const end = range.to;
-          const content = match[1];
+          const content = match[2].replace(/\\~/g, '~');
           tr.replaceWith(
             start,
             end,


### PR DESCRIPTION
Test case: 
- Freely time ~~~~ or ^^^^^ on the editor
- Then it will auto convert to sub or sup when it's ^something^ or ~something~