### PR TITLE
bugfix: slides multiple images rules + codeblock

### DIFF
--- a/package/styles/editor.scss
+++ b/package/styles/editor.scss
@@ -657,22 +657,31 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p {
         margin-bottom: 0;
       }
 
+      pre code {
+        font-size: 1.5vw !important;
+        line-height: 1.5;
+      }
+
+      code {
+        font-size: 1.5vw !important;
+        line-height: 1.5;
+      }
+
       &.solo-slide-image {
         img {
-          max-width: 100%;
           width: auto;
           top: 25%;
           position: relative !important;
           max-width: 1080px;
           aspect-ratio: 16/9;
           object-fit: contain;
+          border-radius: 0.5rem;
         }
       }
 
       img {
-        max-width: 100%;
         width: auto;
-        margin: 2vh auto;
+        // margin: 2vh auto;
         position: relative !important;
         max-width: 1080px;
         aspect-ratio: 16/9;
@@ -730,6 +739,14 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p {
           code {
             font-size: 2.5vw !important;
           }
+        }
+
+        pre code {
+          font-size: 2vw !important;
+        }
+
+        code {
+          font-size: 2vw !important;
         }
       }
     }

--- a/package/utils/handle-print.ts
+++ b/package/utils/handle-print.ts
@@ -148,7 +148,7 @@ export const handlePrint = (slides: string[]) => {
                             padding: 16px;
                             border-radius: 4px;
                             font-family: monospace;
-                            font-size: 20px;
+                            font-size: 16px;
                             margin: 16px 0;
                         }
 


### PR DESCRIPTION
- The inserted code is displayed incorrectly on slides
- Add 2-3 images and not put breaks or text between them

https://docs.google.com/spreadsheets/d/1x2gBs1bl-s2BBwGZqcuPfmCzbAvvpECFD8Eo62WOrTI/edit?pli=1&gid=0#gid=0

