### PR TITLE
feat: suggestion mode (Google Docs-style proposed edits)

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -288,24 +288,26 @@ function App() {
       { ...comment, commentIndex: prev.length, version: '2' },
     ]);
 
-    // If the new comment is a suggestion, also register its serialised anchor
-    // so the decoration system can resolve it after the next render.
-    if (
-      comment.isSuggestion &&
-      comment.id &&
-      meta?.anchorFrom &&
-      meta?.anchorTo
-    ) {
+    // Register the serialized anchor for every new comment that came in with
+    // anchor positions (both regular comments and suggestions). The package's
+    // initialCommentAnchors useEffect resets `commentAnchorsRef.current` to
+    // whatever this prop holds whenever it changes — if a regular comment
+    // isn't included here, a subsequent suggestion submit (which DOES
+    // re-set this state) wipes the regular comment's anchor and its
+    // decoration disappears.
+    if (comment.id && meta?.anchorFrom && meta?.anchorTo) {
       const anchor: SerializedCommentAnchor = {
         id: comment.id,
         anchorFrom: meta.anchorFrom,
         anchorTo: meta.anchorTo,
         resolved: false,
         deleted: false,
-        isSuggestion: true,
-        suggestionType: meta.suggestionType,
-        originalContent: meta.originalContent,
-        suggestedContent: meta.suggestedContent,
+        ...(comment.isSuggestion && {
+          isSuggestion: true,
+          suggestionType: meta.suggestionType,
+          originalContent: meta.originalContent,
+          suggestedContent: meta.suggestedContent,
+        }),
       };
       setInitialCommentAnchors((prev) => [...prev, anchor]);
     }

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -179,6 +179,37 @@ function App() {
   const [disableInlineComment, setDisableInlineComment] = useState(false);
   const [isDDocOwner, setIsDDocOwner] = useState(true);
   const [viewerMode, setViewerMode] = useState<'suggest' | 'view-only' | undefined>(undefined);
+
+  // Single mode picker for the demo navbar — cycles
+  // Owner → Viewer/Suggest → Viewer/View-only → Owner.
+  const cycleMode = () => {
+    if (isDDocOwner) {
+      setIsDDocOwner(false);
+      setIsPreviewMode(true);
+      setViewerMode('suggest');
+    } else if (viewerMode === 'suggest') {
+      setViewerMode('view-only');
+    } else {
+      setIsDDocOwner(true);
+      setIsPreviewMode(false);
+      setViewerMode(undefined);
+    }
+  };
+  const modeIcon = isDDocOwner
+    ? 'Crown'
+    : viewerMode === 'suggest'
+      ? 'PenLine'
+      : 'Eye';
+  const modeLabel = isDDocOwner
+    ? 'Owner'
+    : viewerMode === 'suggest'
+      ? 'Suggest'
+      : 'View-only';
+  const nextModeLabel = isDDocOwner
+    ? 'Suggest'
+    : viewerMode === 'suggest'
+      ? 'View-only'
+      : 'Owner';
   const [initialCommentAnchors, setInitialCommentAnchors] = useState<SerializedCommentAnchor[]>([]);
 
   const searchParams = new URLSearchParams(window.location.search);
@@ -414,12 +445,6 @@ function App() {
           </div>
         </div>
         <div className="flex gap-2">
-          <IconButton
-            variant={'ghost'}
-            icon={disableInlineComment ? 'EyeOff' : 'Eye'}
-            size="md"
-            onClick={() => setDisableInlineComment(!disableInlineComment)}
-          />
           <ThemeToggle />
 
           {isMediaMax1280px ? (
@@ -454,50 +479,25 @@ function App() {
                   </Button>
                   <Button
                     variant={'ghost'}
-                    onClick={() => setIsPreviewMode(!isPreviewMode)}
+                    onClick={cycleMode}
                     className="flex justify-start gap-2"
                   >
-                    <LucideIcon
-                      name={isPreviewMode ? 'Pencil' : 'PencilOff'}
-                      size="sm"
-                    />
-                    {isPreviewMode ? 'Edit' : 'Preview'}
+                    <LucideIcon name={modeIcon} size="sm" />
+                    {modeLabel}
                   </Button>
                   <Button
                     variant={'ghost'}
-                    onClick={() => {
-                      if (isDDocOwner) {
-                        setIsDDocOwner(false);
-                        setIsPreviewMode(true);
-                        setViewerMode('suggest');
-                      } else {
-                        setIsDDocOwner(true);
-                        setIsPreviewMode(false);
-                        setViewerMode(undefined);
-                      }
-                    }}
+                    onClick={() => setDisableInlineComment((v) => !v)}
                     className="flex justify-start gap-2"
                   >
-                    <LucideIcon name={isDDocOwner ? 'Crown' : 'User'} size="sm" />
-                    {isDDocOwner ? 'Owner' : 'Viewer'}
+                    <LucideIcon
+                      name={disableInlineComment ? 'EyeOff' : 'Eye'}
+                      size="sm"
+                    />
+                    {disableInlineComment
+                      ? 'Show inline comments'
+                      : 'Hide inline comments'}
                   </Button>
-                  {!isDDocOwner && (
-                    <Button
-                      variant={'ghost'}
-                      onClick={() =>
-                        setViewerMode((v) =>
-                          v === 'suggest' ? 'view-only' : 'suggest',
-                        )
-                      }
-                      className="flex justify-start gap-2"
-                    >
-                      <LucideIcon
-                        name={viewerMode === 'suggest' ? 'PenLine' : 'Eye'}
-                        size="sm"
-                      />
-                      {viewerMode === 'suggest' ? 'Suggest' : 'View-only'}
-                    </Button>
-                  )}
                   <Button
                     variant={'ghost'}
                     onClick={() => {}}
@@ -521,40 +521,11 @@ function App() {
             <>
               <IconButton
                 variant={'ghost'}
-                icon={isPreviewMode ? 'PencilOff' : 'Pencil'}
+                icon={modeIcon}
                 size="md"
-                onClick={() => setIsPreviewMode(!isPreviewMode)}
+                title={`${modeLabel} mode — click to switch to ${nextModeLabel}`}
+                onClick={cycleMode}
               />
-              <IconButton
-                variant={'ghost'}
-                icon={isDDocOwner ? 'Crown' : 'User'}
-                size="md"
-                title={isDDocOwner ? 'Owner mode' : 'Viewer mode'}
-                onClick={() => {
-                  if (isDDocOwner) {
-                    setIsDDocOwner(false);
-                    setIsPreviewMode(true);
-                    setViewerMode('suggest');
-                  } else {
-                    setIsDDocOwner(true);
-                    setIsPreviewMode(false);
-                    setViewerMode(undefined);
-                  }
-                }}
-              />
-              {!isDDocOwner && (
-                <IconButton
-                  variant={'ghost'}
-                  icon={viewerMode === 'suggest' ? 'PenLine' : 'Eye'}
-                  size="md"
-                  title={viewerMode === 'suggest' ? 'Suggest mode' : 'View-only mode'}
-                  onClick={() =>
-                    setViewerMode((v) =>
-                      v === 'suggest' ? 'view-only' : 'suggest',
-                    )
-                  }
-                />
-              )}
               <IconButton
                 variant={'ghost'}
                 icon="Presentation"

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -23,6 +23,8 @@ import {
   DocumentStyling,
   CollaborationProps,
   CollabState,
+  SerializedCommentAnchor,
+  CommentMutationMeta,
 } from '../../package/types';
 import {
   getKeyFromURLParams,
@@ -175,6 +177,9 @@ function App() {
   const [isNavbarVisible, setIsNavbarVisible] = useState(true);
   const [isPreviewMode, setIsPreviewMode] = useState(false);
   const [disableInlineComment, setDisableInlineComment] = useState(false);
+  const [isDDocOwner, setIsDDocOwner] = useState(true);
+  const [viewerMode, setViewerMode] = useState<'suggest' | 'view-only' | undefined>(undefined);
+  const [initialCommentAnchors, setInitialCommentAnchors] = useState<SerializedCommentAnchor[]>([]);
 
   const searchParams = new URLSearchParams(window.location.search);
   const paramCollaborationId = searchParams.get('collaborationId');
@@ -246,11 +251,33 @@ function App() {
       }),
     );
   };
-  const handleNewComment = (comment: IComment) => {
+  const handleNewComment = (comment: IComment, meta?: CommentMutationMeta) => {
     setInitialComment((prev) => [
       ...prev,
       { ...comment, commentIndex: prev.length, version: '2' },
     ]);
+
+    // If the new comment is a suggestion, also register its serialised anchor
+    // so the decoration system can resolve it after the next render.
+    if (
+      comment.isSuggestion &&
+      comment.id &&
+      meta?.anchorFrom &&
+      meta?.anchorTo
+    ) {
+      const anchor: SerializedCommentAnchor = {
+        id: comment.id,
+        anchorFrom: meta.anchorFrom,
+        anchorTo: meta.anchorTo,
+        resolved: false,
+        deleted: false,
+        isSuggestion: true,
+        suggestionType: meta.suggestionType,
+        originalContent: meta.originalContent,
+        suggestedContent: meta.suggestedContent,
+      };
+      setInitialCommentAnchors((prev) => [...prev, anchor]);
+    }
   };
   const handleResolveComment = (commentId: string) => {
     setInitialComment(
@@ -438,6 +465,41 @@ function App() {
                   </Button>
                   <Button
                     variant={'ghost'}
+                    onClick={() => {
+                      if (isDDocOwner) {
+                        setIsDDocOwner(false);
+                        setIsPreviewMode(true);
+                        setViewerMode('suggest');
+                      } else {
+                        setIsDDocOwner(true);
+                        setIsPreviewMode(false);
+                        setViewerMode(undefined);
+                      }
+                    }}
+                    className="flex justify-start gap-2"
+                  >
+                    <LucideIcon name={isDDocOwner ? 'Crown' : 'User'} size="sm" />
+                    {isDDocOwner ? 'Owner' : 'Viewer'}
+                  </Button>
+                  {!isDDocOwner && (
+                    <Button
+                      variant={'ghost'}
+                      onClick={() =>
+                        setViewerMode((v) =>
+                          v === 'suggest' ? 'view-only' : 'suggest',
+                        )
+                      }
+                      className="flex justify-start gap-2"
+                    >
+                      <LucideIcon
+                        name={viewerMode === 'suggest' ? 'PenLine' : 'Eye'}
+                        size="sm"
+                      />
+                      {viewerMode === 'suggest' ? 'Suggest' : 'View-only'}
+                    </Button>
+                  )}
+                  <Button
+                    variant={'ghost'}
                     onClick={() => {}}
                     className="flex justify-start gap-2"
                   >
@@ -463,6 +525,36 @@ function App() {
                 size="md"
                 onClick={() => setIsPreviewMode(!isPreviewMode)}
               />
+              <IconButton
+                variant={'ghost'}
+                icon={isDDocOwner ? 'Crown' : 'User'}
+                size="md"
+                title={isDDocOwner ? 'Owner mode' : 'Viewer mode'}
+                onClick={() => {
+                  if (isDDocOwner) {
+                    setIsDDocOwner(false);
+                    setIsPreviewMode(true);
+                    setViewerMode('suggest');
+                  } else {
+                    setIsDDocOwner(true);
+                    setIsPreviewMode(false);
+                    setViewerMode(undefined);
+                  }
+                }}
+              />
+              {!isDDocOwner && (
+                <IconButton
+                  variant={'ghost'}
+                  icon={viewerMode === 'suggest' ? 'PenLine' : 'Eye'}
+                  size="md"
+                  title={viewerMode === 'suggest' ? 'Suggest mode' : 'View-only mode'}
+                  onClick={() =>
+                    setViewerMode((v) =>
+                      v === 'suggest' ? 'view-only' : 'suggest',
+                    )
+                  }
+                />
+              )}
               <IconButton
                 variant={'ghost'}
                 icon="Presentation"
@@ -720,7 +812,9 @@ function App() {
         }}
         onCollaboratorChange={onCollaboratorChange}
         documentStyling={documentStyling}
-        isDDocOwner={true}
+        isDDocOwner={isDDocOwner}
+        viewerMode={isDDocOwner ? undefined : viewerMode}
+        initialCommentAnchors={initialCommentAnchors}
         setCharacterCount={setCharacterCount}
         setWordCount={setWordCount}
         setPageCount={setPageCount}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.9-sg-2",
+  "version": "3.2.9-sg-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.9-sg-2",
+      "version": "3.2.9-sg-3",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.1.8",
+  "version": "3.1.8-sg-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.1.8",
+      "version": "3.1.8-sg-2",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.2-sg-6",
+  "version": "3.2.2-sg-7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.2-sg-6",
+      "version": "3.2.2-sg-7",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.2-sg-5",
+  "version": "3.2.2-sg-6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.2-sg-5",
+      "version": "3.2.2-sg-6",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.2-sg-3",
+  "version": "3.2.2-sg-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.2-sg-3",
+      "version": "3.2.2-sg-4",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.2-sg-4",
+  "version": "3.2.2-sg-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.2-sg-4",
+      "version": "3.2.2-sg-5",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.6-sg-4",
+  "version": "3.2.6-sg-6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.6-sg-4",
+      "version": "3.2.6-sg-6",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.9-sg-3",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.9-sg-3",
+      "version": "3.3.0",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.1.8-sg-2",
+  "version": "3.1.8-sg-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.1.8-sg-2",
+      "version": "3.1.8-sg-4",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.6-sg-2",
+  "version": "3.2.6-sg-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.6-sg-2",
+      "version": "3.2.6-sg-4",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.2-sg-1",
+  "version": "3.2.2-sg-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.2-sg-1",
+      "version": "3.2.2-sg-2",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.9",
+  "version": "3.2.9-sg-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.9",
+      "version": "3.2.9-sg-1",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.1.7-comment-re-arch-23",
+  "version": "3.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.1.7-comment-re-arch-23",
+      "version": "3.1.8",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.2-sg-2",
+  "version": "3.2.2-sg-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.2-sg-2",
+      "version": "3.2.2-sg-3",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.6",
+  "version": "3.2.6-sg-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.6",
+      "version": "3.2.6-sg-1",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.1.8-sg-4",
+  "version": "3.2.1-sg-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.1.8-sg-4",
+      "version": "3.2.1-sg-1",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",
@@ -120,7 +120,7 @@
         "@dnd-kit/sortable": ">=10.0.0",
         "@dnd-kit/utilities": ">=3.2.2",
         "@fileverse/crypto": ">=0.0.21",
-        "@fileverse/ui": ">=5.1.1",
+        "@fileverse/ui": ">=5.1.2",
         "framer-motion": ">=11.2.10",
         "frimousse": ">=0.3.0",
         "viem": ">=2.13.8"
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@fileverse/ui": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@fileverse/ui/-/ui-5.1.1.tgz",
-      "integrity": "sha512-swmapzYCRs3dhZBOYbTJR8aPNBgD/VQshsE78eKuKpmUkpxW/LC29BjTlDhdjlUVfrcQ7gH3vfwo5OPdjaHxTg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@fileverse/ui/-/ui-5.1.2.tgz",
+      "integrity": "sha512-G7Utw05y/A5raHeOjr7OKXamEDqoIXzCbc8Nz9l1AURW7Ehi4T5uuyDJ0OgdE5ayJnhLlLyTExJwzwHr3OBb3w==",
       "peer": true,
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.1",
+  "version": "3.1.7-comment-re-arch-23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.1",
+      "version": "3.1.7-comment-re-arch-23",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",
@@ -120,7 +120,7 @@
         "@dnd-kit/sortable": ">=10.0.0",
         "@dnd-kit/utilities": ">=3.2.2",
         "@fileverse/crypto": ">=0.0.21",
-        "@fileverse/ui": ">=5.1.2",
+        "@fileverse/ui": ">=5.1.1",
         "framer-motion": ">=11.2.10",
         "frimousse": ">=0.3.0",
         "viem": ">=2.13.8"
@@ -1186,9 +1186,9 @@
       }
     },
     "node_modules/@fileverse/ui": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@fileverse/ui/-/ui-5.1.2.tgz",
-      "integrity": "sha512-G7Utw05y/A5raHeOjr7OKXamEDqoIXzCbc8Nz9l1AURW7Ehi4T5uuyDJ0OgdE5ayJnhLlLyTExJwzwHr3OBb3w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fileverse/ui/-/ui-5.1.1.tgz",
+      "integrity": "sha512-swmapzYCRs3dhZBOYbTJR8aPNBgD/VQshsE78eKuKpmUkpxW/LC29BjTlDhdjlUVfrcQ7gH3vfwo5OPdjaHxTg==",
       "peer": true,
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.6-sg-1",
+  "version": "3.2.6-sg-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.6-sg-1",
+      "version": "3.2.6-sg-2",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.2.9-sg-1",
+  "version": "3.2.9-sg-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.2.9-sg-1",
+      "version": "3.2.9-sg-2",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.9-sg-1",
+  "version": "3.2.9-sg-2",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.2-sg-4",
+  "version": "3.2.2-sg-5",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.9-sg-2",
+  "version": "3.2.9-sg-3",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.6",
+  "version": "3.2.6-sg-1",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.6-sg-4",
+  "version": "3.2.6-sg-6",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.2-sg-5",
+  "version": "3.2.2-sg-6",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.9-sg-3",
+  "version": "3.3.0",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.6-sg-2",
+  "version": "3.2.6-sg-4",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.2-sg-6",
+  "version": "3.2.2-sg-7",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.6-sg-1",
+  "version": "3.2.6-sg-2",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.2-sg-1",
+  "version": "3.2.2-sg-2",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.9",
+  "version": "3.2.9-sg-1",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.2-sg-2",
+  "version": "3.2.2-sg-3",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.2-sg-3",
+  "version": "3.2.2-sg-4",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.2.1",
+  "version": "3.2.1-sg-1",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package/components/inline-comment/comment-card.tsx
+++ b/package/components/inline-comment/comment-card.tsx
@@ -27,58 +27,7 @@ import { Spinner } from '../../common/spinner';
 import { DeleteConfirmOverlay } from './delete-confirm-overlay';
 import { useCommentCard } from './use-comment-card';
 import { useEnsStatus } from './use-ens-status';
-import { SuggestionType } from '../../types';
-
-interface SuggestionDiffSummaryProps {
-  suggestionType?: SuggestionType;
-  originalContent?: string;
-  suggestedContent?: string;
-}
-
-// One-line diff summary used in the sidebar entry for suggestion comments.
-// Mirrors the format used by SuggestionThreadFloatingCard so suggestion
-// representation stays consistent across surfaces.
-const SuggestionDiffSummary = ({
-  suggestionType,
-  originalContent = '',
-  suggestedContent = '',
-}: SuggestionDiffSummaryProps) => {
-  if (suggestionType === 'add') {
-    return (
-      <p className="text-body-sm break-words">
-        <span className="font-semibold">Add:</span>{' '}
-        <span>&ldquo;{suggestedContent}&rdquo;</span>
-      </p>
-    );
-  }
-  if (suggestionType === 'delete') {
-    return (
-      <p className="text-body-sm break-words">
-        <span className="font-semibold">Delete:</span>{' '}
-        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>
-      </p>
-    );
-  }
-  if (suggestionType === 'replace') {
-    return (
-      <p className="text-body-sm break-words">
-        <span className="font-semibold">Replace:</span>{' '}
-        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>{' '}
-        <span className="font-semibold">with</span>{' '}
-        <span>&ldquo;{suggestedContent}&rdquo;</span>
-      </p>
-    );
-  }
-  if (suggestionType === 'link') {
-    return (
-      <p className="text-body-sm break-words">
-        <span className="font-semibold">Add link:</span>{' '}
-        <span>&quot;{suggestedContent}&quot;</span>
-      </p>
-    );
-  }
-  return null;
-};
+import { SuggestionDiffSummary } from './suggestion-diff-summary';
 
 const UserDisplay = ({ username, createdAt }: UserDisplayProps) => {
   const ensStatus = useEnsStatus(username);

--- a/package/components/inline-comment/comment-card.tsx
+++ b/package/components/inline-comment/comment-card.tsx
@@ -364,6 +364,7 @@ export const CommentCard = (props: CommentCardProps) => {
     id,
     isDisabled,
     isCommentOwner,
+    canResolveComment,
     isCommentDrawerContext,
     isDropdown,
     isSuggestion,
@@ -401,6 +402,7 @@ export const CommentCard = (props: CommentCardProps) => {
   // const isStrictCommentOwner = Boolean(
   //   currentUsername && username && username === currentUsername,
   // );
+  const canShowResolveAction = canResolveComment ?? isCommentOwner;
 
   if (emptyComment)
     return (
@@ -450,9 +452,12 @@ export const CommentCard = (props: CommentCardProps) => {
                   'flex  gap-[4px]',
                 )}
               >
-                {isCommentOwner && !isResolved && (
+                {canShowResolveAction && !isResolved && (
                   <Tooltip
-                    text={!isDisabled && 'Mark as resolved'}
+                    text={
+                      !isDisabled &&
+                      (isSuggestion ? 'Accept suggestion' : 'Mark as resolved')
+                    }
                     position="bottom"
                   >
                     <IconButton
@@ -486,7 +491,7 @@ export const CommentCard = (props: CommentCardProps) => {
                           className="flex flex-col p-2 w-40 shadow-elevation-3"
                           onClick={(e) => e.stopPropagation()}
                         >
-                          {isResolved && (
+                          {isResolved && !isSuggestion && (
                             <button
                               className="flex items-center h-[32px] color-text-default gap-[12px] rounded p-2 transition-all hover:color-bg-default-hover w-full"
                               onClick={handleUnresolveClick}

--- a/package/components/inline-comment/comment-card.tsx
+++ b/package/components/inline-comment/comment-card.tsx
@@ -443,7 +443,7 @@ export const CommentCard = (props: CommentCardProps) => {
       data-testid={id ? `comment-card-${id}` : 'comment-card'}
       onClick={focusCardIfNeeded}
       className={cn(
-        'flex flex-col gap-[4px] group comment-card',
+        'flex flex-col gap-[4px] group/card comment-card',
         isResolved && 'opacity-70',
         isCommentDrawerContext ? 'p-3 pb-0' : 'px-3',
       )}
@@ -459,7 +459,7 @@ export const CommentCard = (props: CommentCardProps) => {
             >
               <div
                 className={cn(
-                  !isBelow1280px && 'opacity-0 group-hover:opacity-100',
+                  !isBelow1280px && 'opacity-0 group-hover/card:opacity-100',
                   'flex  gap-[4px]',
                 )}
               >

--- a/package/components/inline-comment/comment-card.tsx
+++ b/package/components/inline-comment/comment-card.tsx
@@ -45,7 +45,7 @@ const SuggestionDiffSummary = ({
 }: SuggestionDiffSummaryProps) => {
   if (suggestionType === 'add') {
     return (
-      <p className="text-body-sm">
+      <p className="text-body-sm break-words">
         <span className="font-semibold">Add:</span>{' '}
         <span>&ldquo;{suggestedContent}&rdquo;</span>
       </p>
@@ -53,7 +53,7 @@ const SuggestionDiffSummary = ({
   }
   if (suggestionType === 'delete') {
     return (
-      <p className="text-body-sm">
+      <p className="text-body-sm break-words">
         <span className="font-semibold">Delete:</span>{' '}
         <span className="line-through">&ldquo;{originalContent}&rdquo;</span>
       </p>
@@ -61,11 +61,19 @@ const SuggestionDiffSummary = ({
   }
   if (suggestionType === 'replace') {
     return (
-      <p className="text-body-sm">
+      <p className="text-body-sm break-words">
         <span className="font-semibold">Replace:</span>{' '}
         <span className="line-through">&ldquo;{originalContent}&rdquo;</span>{' '}
         <span className="font-semibold">with</span>{' '}
         <span>&ldquo;{suggestedContent}&rdquo;</span>
+      </p>
+    );
+  }
+  if (suggestionType === 'link') {
+    return (
+      <p className="text-body-sm break-words">
+        <span className="font-semibold">Add link:</span>{' '}
+        <span>&quot;{suggestedContent}&quot;</span>
       </p>
     );
   }

--- a/package/components/inline-comment/comment-card.tsx
+++ b/package/components/inline-comment/comment-card.tsx
@@ -7,8 +7,13 @@ import {
   Skeleton,
   Tooltip,
 } from '@fileverse/ui';
-import { useState } from 'react';
-import { CommentCardProps, CommentReplyProps, UserDisplayProps } from './types';
+import { useState, type MouseEvent } from 'react';
+import {
+  CommentCardProps,
+  CommentReplyProps,
+  EnsStatus,
+  UserDisplayProps,
+} from './types';
 import { useCommentStore } from '../../stores/comment-store';
 import EnsLogo from '../../assets/ens.svg';
 import verifiedMark from '../../assets/ens-check.svg';
@@ -102,7 +107,7 @@ const UserDisplay = ({ username, createdAt }: UserDisplayProps) => {
   );
 };
 
-const CommentReply = ({
+export const CommentReply = ({
   commentId,
   replyId,
   reply,
@@ -243,6 +248,106 @@ const CommentReply = ({
         onCancel={handleDeleteOverlayClose}
         onConfirm={handleDeleteReply}
       />
+    </div>
+  );
+};
+
+interface CommentRepliesThreadProps {
+  id?: string;
+  displayedReplies: CommentCardProps['replies'];
+  ensStatus: EnsStatus;
+  handleReplyToggleClick: (event: MouseEvent<HTMLElement>) => void;
+  isCommentDrawerContext?: boolean;
+  isResolved?: boolean;
+  replyToggleLabel: string;
+  shouldShowReplyThread: boolean;
+  shouldShowReplyToggle: boolean;
+  shouldShowResolvedMobileReplyCount: boolean;
+  showAllReplies: boolean;
+  visibleReplies: CommentCardProps['replies'];
+}
+
+export const CommentRepliesThread = ({
+  id,
+  displayedReplies,
+  ensStatus,
+  handleReplyToggleClick,
+  isCommentDrawerContext,
+  isResolved,
+  replyToggleLabel,
+  shouldShowReplyThread,
+  shouldShowReplyToggle,
+  shouldShowResolvedMobileReplyCount,
+  showAllReplies,
+  visibleReplies,
+}: CommentRepliesThreadProps) => {
+  if (!visibleReplies?.length) {
+    return null;
+  }
+
+  return shouldShowResolvedMobileReplyCount ? (
+    <button
+      type="button"
+      onClick={handleReplyToggleClick}
+      className="text-helper-text-sm color-text-secondary text-left hover:underline"
+    >
+      {visibleReplies.length} replies
+    </button>
+  ) : (
+    <div className="flex flex-col gap-0 relative">
+      {shouldShowReplyToggle && (
+        <div
+          onClick={handleReplyToggleClick}
+          className={cn(
+            'text-helper-text-sm color-text-secondary min-h-[28px] mb-[4px] hover:underline custom-border cursor-pointer flex items-center gap-2 pr-[8px] pl-[4px]',
+            !shouldShowReplyThread && 'justify-center mt-[4px]',
+          )}
+        >
+          <IconButton
+            icon={showAllReplies ? 'ChevronUp' : 'ChevronDown'}
+            variant="ghost"
+            size="sm"
+            rounded
+            className="color-text-secondary border custom-border !min-w-[20px] !w-[20px] !h-[20px]"
+            onClick={handleReplyToggleClick}
+          />
+          {!showAllReplies && (
+            <div className="flex items-center -space-x-1">
+              {visibleReplies.slice(0, 2).map((reply) => (
+                <Avatar
+                  src={
+                    ensStatus.isEns
+                      ? EnsLogo
+                      : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
+                          reply.username || '',
+                        )}`
+                  }
+                  size="sm"
+                  className="w-4 h-4 last:z-10 bg-transparent"
+                  bordered="border"
+                  key={reply.id}
+                />
+              ))}
+            </div>
+          )}
+          {replyToggleLabel}
+        </div>
+      )}
+
+      {shouldShowReplyThread &&
+        displayedReplies?.map((reply, index) => (
+          <CommentReply
+            key={reply.id}
+            commentId={id as string}
+            replyId={reply.id || ''}
+            reply={reply.content || ''}
+            username={reply.username || ''}
+            createdAt={reply.createdAt || new Date()}
+            isLast={index === displayedReplies.length - 1}
+            isThreadResolved={isResolved}
+            isCommentDrawerContext={isCommentDrawerContext}
+          />
+        ))}
     </div>
   );
 };
@@ -474,74 +579,20 @@ export const CommentCard = (props: CommentCardProps) => {
         </div>
       </div>
 
-      {visibleReplies.length > 0 &&
-        (shouldShowResolvedMobileReplyCount ? (
-          // Mobile resolved threads stay compact by default, but the count can
-          // still expand the thread on demand.
-          <button
-            type="button"
-            onClick={handleReplyToggleClick}
-            className="text-helper-text-sm color-text-secondary text-left hover:underline"
-          >
-            {visibleReplies.length} replies
-          </button>
-        ) : (
-          <div className="flex flex-col gap-0 relative">
-            {shouldShowReplyToggle && (
-              <div
-                onClick={handleReplyToggleClick}
-                className={cn(
-                  'text-helper-text-sm color-text-secondary min-h-[28px] mb-[4px] hover:underline custom-border cursor-pointer flex items-center gap-2 pr-[8px] pl-[4px]',
-                  !shouldShowReplyThread && 'justify-center mt-[4px]',
-                )}
-              >
-                <IconButton
-                  icon={showAllReplies ? 'ChevronUp' : 'ChevronDown'}
-                  variant="ghost"
-                  size="sm"
-                  rounded
-                  className="color-text-secondary border custom-border !min-w-[20px] !w-[20px] !h-[20px]"
-                  onClick={handleReplyToggleClick}
-                />
-                {!showAllReplies && (
-                  <div className="flex items-center -space-x-1">
-                    {visibleReplies.slice(0, 2).map((reply) => (
-                      <Avatar
-                        src={
-                          ensStatus.isEns
-                            ? EnsLogo
-                            : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
-                                reply.username || '',
-                              )}`
-                        }
-                        size="sm"
-                        className="w-4 h-4 last:z-10 bg-transparent"
-                        bordered="border"
-                        key={reply.id}
-                      />
-                    ))}
-                  </div>
-                )}
-                {replyToggleLabel}
-              </div>
-            )}
-
-            {shouldShowReplyThread &&
-              displayedReplies.map((reply, index) => (
-                <CommentReply
-                  key={reply.id}
-                  commentId={id as string}
-                  replyId={reply.id || ''}
-                  reply={reply.content || ''}
-                  username={reply.username || ''}
-                  createdAt={reply.createdAt || new Date()}
-                  isLast={index === displayedReplies.length - 1}
-                  isThreadResolved={isResolved}
-                  isCommentDrawerContext={isCommentDrawerContext}
-                />
-              ))}
-          </div>
-        ))}
+      <CommentRepliesThread
+        id={id}
+        displayedReplies={displayedReplies}
+        ensStatus={ensStatus}
+        handleReplyToggleClick={handleReplyToggleClick}
+        isCommentDrawerContext={isCommentDrawerContext}
+        isResolved={isResolved}
+        replyToggleLabel={replyToggleLabel}
+        shouldShowReplyThread={shouldShowReplyThread}
+        shouldShowReplyToggle={shouldShowReplyToggle}
+        shouldShowResolvedMobileReplyCount={shouldShowResolvedMobileReplyCount}
+        showAllReplies={showAllReplies}
+        visibleReplies={visibleReplies}
+      />
     </div>
   );
 };

--- a/package/components/inline-comment/comment-card.tsx
+++ b/package/components/inline-comment/comment-card.tsx
@@ -21,6 +21,50 @@ import { Spinner } from '../../common/spinner';
 import { DeleteConfirmOverlay } from './delete-confirm-overlay';
 import { useCommentCard } from './use-comment-card';
 import { useEnsStatus } from './use-ens-status';
+import { SuggestionType } from '../../types';
+
+interface SuggestionDiffSummaryProps {
+  suggestionType?: SuggestionType;
+  originalContent?: string;
+  suggestedContent?: string;
+}
+
+// One-line diff summary used in the sidebar entry for suggestion comments.
+// Mirrors the format used by SuggestionThreadFloatingCard so suggestion
+// representation stays consistent across surfaces.
+const SuggestionDiffSummary = ({
+  suggestionType,
+  originalContent = '',
+  suggestedContent = '',
+}: SuggestionDiffSummaryProps) => {
+  if (suggestionType === 'add') {
+    return (
+      <p className="text-body-sm">
+        <span className="font-semibold">Add:</span>{' '}
+        <span>&ldquo;{suggestedContent}&rdquo;</span>
+      </p>
+    );
+  }
+  if (suggestionType === 'delete') {
+    return (
+      <p className="text-body-sm">
+        <span className="font-semibold">Delete:</span>{' '}
+        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>
+      </p>
+    );
+  }
+  if (suggestionType === 'replace') {
+    return (
+      <p className="text-body-sm">
+        <span className="font-semibold">Replace:</span>{' '}
+        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>{' '}
+        <span className="font-semibold">with</span>{' '}
+        <span>&ldquo;{suggestedContent}&rdquo;</span>
+      </p>
+    );
+  }
+  return null;
+};
 
 const UserDisplay = ({ username, createdAt }: UserDisplayProps) => {
   const ensStatus = useEnsStatus(username);
@@ -217,6 +261,10 @@ export const CommentCard = (props: CommentCardProps) => {
     isCommentOwner,
     isCommentDrawerContext,
     isDropdown,
+    isSuggestion,
+    suggestionType,
+    originalContent,
+    suggestedContent,
   } = props;
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { onDelete: _onDelete } = props;
@@ -399,21 +447,29 @@ export const CommentCard = (props: CommentCardProps) => {
               : 'ml-[15px]',
           )}
         >
-          {comment && (
-            <div>
-              <div className="text-body-sm whitespace-pre-wrap break-words">
-                {renderTextWithLinks(displayedComment || '')}
+          {isSuggestion ? (
+            <SuggestionDiffSummary
+              suggestionType={suggestionType}
+              originalContent={originalContent}
+              suggestedContent={suggestedContent}
+            />
+          ) : (
+            comment && (
+              <div>
+                <div className="text-body-sm whitespace-pre-wrap break-words">
+                  {renderTextWithLinks(displayedComment || '')}
+                </div>
+                {isCommentTruncated && (
+                  <button
+                    type="button"
+                    onClick={handleCommentExpandClick}
+                    className="color-text-link mt-[4px] cursor-pointer text-helper-text-sm"
+                  >
+                    {isCommentExpanded ? 'Show less' : 'Show more'}
+                  </button>
+                )}
               </div>
-              {isCommentTruncated && (
-                <button
-                  type="button"
-                  onClick={handleCommentExpandClick}
-                  className="color-text-link mt-[4px] cursor-pointer text-helper-text-sm"
-                >
-                  {isCommentExpanded ? 'Show less' : 'Show more'}
-                </button>
-              )}
-            </div>
+            )
           )}
         </div>
       </div>

--- a/package/components/inline-comment/comment-drawer-constants.ts
+++ b/package/components/inline-comment/comment-drawer-constants.ts
@@ -1,0 +1,1 @@
+export const ALL_TABS_OPTION_ID = '__all_tabs__';

--- a/package/components/inline-comment/comment-drawer-desktop.tsx
+++ b/package/components/inline-comment/comment-drawer-desktop.tsx
@@ -1,0 +1,152 @@
+import {
+  DynamicDrawerV2,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@fileverse/ui';
+import cn from 'classnames';
+import { CommentSection } from './comment-section';
+import type { IComment } from '../../extensions/comment';
+
+interface DrawerSelectOption {
+  id: string;
+  label: string;
+}
+
+interface CommentDrawerDesktopProps {
+  activeCommentId: string | null;
+  commentType: string;
+  commentTypeOptions: DrawerSelectOption[];
+  filteredComments: IComment[];
+  isCollaborationEnabled: boolean;
+  isCommentTypeSelectOpen: boolean;
+  isConnected: boolean;
+  isNavbarVisible: boolean;
+  isOpen: boolean;
+  isPresentationMode: boolean;
+  isPreviewMode: boolean;
+  isTabSelectOpen: boolean;
+  newCommentTabId: string;
+  onClose: () => void;
+  onCommentFocus: (commentId: string, tabId?: string) => void;
+  onCommentTypeChange: (commentType: string) => void;
+  onCommentTypeSelectOpenChange: (open: boolean) => void;
+  onReset: () => void;
+  onTabChange: (tabId: string) => void;
+  onTabSelectOpenChange: (open: boolean) => void;
+  sectionLabel: string;
+  selectedTab: string;
+  selectedTabLabel: string;
+  tabList: DrawerSelectOption[];
+  tabNameById: Record<string, string>;
+}
+
+export const CommentDrawerDesktop = ({
+  activeCommentId,
+  commentType,
+  commentTypeOptions,
+  filteredComments,
+  isCollaborationEnabled,
+  isCommentTypeSelectOpen,
+  isConnected,
+  isNavbarVisible,
+  isOpen,
+  isPresentationMode,
+  isPreviewMode,
+  isTabSelectOpen,
+  newCommentTabId,
+  onClose,
+  onCommentFocus,
+  onCommentTypeChange,
+  onCommentTypeSelectOpenChange,
+  onReset,
+  onTabChange,
+  onTabSelectOpenChange,
+  sectionLabel,
+  selectedTab,
+  selectedTabLabel,
+  tabList,
+  tabNameById,
+}: CommentDrawerDesktopProps) => (
+  <DynamicDrawerV2
+    open={isOpen}
+    onOpenChange={onClose}
+    side="right"
+    rounded={true}
+    dismissible
+    className={cn(
+      'w-[336px] !z-40 right-0 shadow-elevation-4 rounded-lg border color-border-default',
+      isOpen && 'right-2 md:!right-4',
+      isNavbarVisible
+        ? `h-[calc(98vh-140px)] ${isPreviewMode ? 'top-[4rem]' : 'top-[7.25rem] '}`
+        : 'top-[4rem] h-[calc(100vh-90px)] xl:h-[calc(99vh-90px)]',
+      isPresentationMode && 'h-[calc(100vh-5rem)] top-[4rem] !z-[60]',
+    )}
+    headerClassName="border-b color-border-default !color-bg-default px-4 pb-[12px] !rounded-t-lg"
+    contentClassName="!rounded-lg !px-0 !h-full !pb-5 select-text"
+    title="Comments"
+    content={
+      <div
+        className={cn(
+          'pt-4',
+          !isConnected && isPreviewMode && 'flex items-center h-[77dvh]',
+        )}
+      >
+        {(isConnected || isCollaborationEnabled) && (
+          <div className="flex mb-[16px] px-4 gap-[8px]">
+            <Select
+              value={commentType}
+              open={isCommentTypeSelectOpen}
+              onOpenChange={onCommentTypeSelectOpenChange}
+              onValueChange={onCommentTypeChange}
+            >
+              <SelectTrigger className="w-[148px]">
+                <SelectValue placeholder="Active" />
+              </SelectTrigger>
+              <SelectContent>
+                {commentTypeOptions.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select
+              value={selectedTab}
+              open={isTabSelectOpen}
+              onOpenChange={onTabSelectOpenChange}
+              onValueChange={onTabChange}
+            >
+              <SelectTrigger className="w-[148px]">
+                <SelectValue placeholder="All tabs" />
+              </SelectTrigger>
+              <SelectContent>
+                {tabList.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+        <CommentSection
+          activeCommentId={activeCommentId}
+          isNavbarVisible={isNavbarVisible}
+          isPresentationMode={isPresentationMode}
+          comments={filteredComments}
+          commentType={commentType as 'all' | 'active' | 'resolved'}
+          sectionLabel={sectionLabel}
+          tabNameById={tabNameById}
+          selectedTabLabel={selectedTabLabel}
+          newCommentTabId={newCommentTabId}
+          onCommentFocus={onCommentFocus}
+          onReset={onReset}
+          isCollaborationEnabled={isCollaborationEnabled}
+        />
+      </div>
+    }
+  />
+);

--- a/package/components/inline-comment/comment-drawer-mobile.tsx
+++ b/package/components/inline-comment/comment-drawer-mobile.tsx
@@ -37,6 +37,7 @@ interface CommentDrawerMobileProps {
   onCommentFocus: (commentId: string, tabId?: string) => void;
   onCreateComment: () => void;
   onDiscardSuggestionDraft: () => void;
+  onFocusSuggestionDraft: () => void;
   onNextMobileComment: () => void;
   onPreviousMobileComment: () => void;
   onStartNewMobileComment: () => void;
@@ -75,6 +76,7 @@ export const CommentDrawerMobile = ({
   onCommentFocus,
   onCreateComment,
   onDiscardSuggestionDraft,
+  onFocusSuggestionDraft,
   onNextMobileComment,
   onPreviousMobileComment,
   onStartNewMobileComment,
@@ -100,6 +102,7 @@ export const CommentDrawerMobile = ({
         onAttemptClose={onAttemptCloseSuggestionDraft}
         onCancelDiscard={onCancelDiscardSuggestion}
         onConfirmDiscard={onDiscardSuggestionDraft}
+        onFocusSuggestionText={onFocusSuggestionDraft}
         onSubmit={onSubmitSuggestionDraft}
       />
     ) : isInlineDraftOpen ? (

--- a/package/components/inline-comment/comment-drawer-mobile.tsx
+++ b/package/components/inline-comment/comment-drawer-mobile.tsx
@@ -1,0 +1,205 @@
+import { IconButton } from '@fileverse/ui';
+import cn from 'classnames';
+import { CommentSection } from './comment-section';
+import { MobileInlineComment } from './mobile-inline-comment-sheet';
+import { MobileSuggestionDraft } from './mobile-suggestion-draft-sheet';
+import type { IComment } from '../../extensions/comment';
+import type {
+  InlineCommentDraft,
+  SuggestionFloatingDraftCard,
+} from './context/types';
+
+interface CommentDrawerMobileProps {
+  activeCommentId: string | null;
+  activeDraft: InlineCommentDraft | null;
+  activeDraftId: string | null;
+  activeSuggestionDraftCard: SuggestionFloatingDraftCard | null;
+  canGoToNextMobileComment: boolean;
+  canGoToPreviousMobileComment: boolean;
+  comments: IComment[];
+  isCollaborationEnabled: boolean;
+  isCommentMobileFocused: boolean;
+  isConnected: boolean;
+  isDiscardCommentOverlayVisible: boolean;
+  isDiscardSuggestionOverlayVisible: boolean;
+  isInlineDraftOpen: boolean;
+  isMobileDrawerVisible: boolean;
+  isNavbarVisible: boolean;
+  isPresentationMode: boolean;
+  mobileActiveCommentsCount: number;
+  mobileDraftRef: React.RefObject<HTMLDivElement>;
+  mobileFocusedCommentIndex: number;
+  onAttemptCloseNewComment: () => void;
+  onAttemptCloseSuggestionDraft: () => void;
+  onCancelDiscardComment: () => void;
+  onCancelDiscardSuggestion: () => void;
+  onCloseDrawer: () => void;
+  onCommentFocus: (commentId: string, tabId?: string) => void;
+  onCreateComment: () => void;
+  onDiscardSuggestionDraft: () => void;
+  onNextMobileComment: () => void;
+  onPreviousMobileComment: () => void;
+  onStartNewMobileComment: () => void;
+  onSubmitSuggestionDraft: () => void;
+  onUpdateInlineDraftText: (draftId: string, text: string) => void;
+  onViewAllComments: () => void;
+  tabNameById: Record<string, string>;
+  username: string | null;
+}
+
+export const CommentDrawerMobile = ({
+  activeCommentId,
+  activeDraft,
+  activeDraftId,
+  activeSuggestionDraftCard,
+  canGoToNextMobileComment,
+  canGoToPreviousMobileComment,
+  comments,
+  isCollaborationEnabled,
+  isCommentMobileFocused,
+  isConnected,
+  isDiscardCommentOverlayVisible,
+  isDiscardSuggestionOverlayVisible,
+  isInlineDraftOpen,
+  isMobileDrawerVisible,
+  isNavbarVisible,
+  isPresentationMode,
+  mobileActiveCommentsCount,
+  mobileDraftRef,
+  mobileFocusedCommentIndex,
+  onAttemptCloseNewComment,
+  onAttemptCloseSuggestionDraft,
+  onCancelDiscardComment,
+  onCancelDiscardSuggestion,
+  onCloseDrawer,
+  onCommentFocus,
+  onCreateComment,
+  onDiscardSuggestionDraft,
+  onNextMobileComment,
+  onPreviousMobileComment,
+  onStartNewMobileComment,
+  onSubmitSuggestionDraft,
+  onUpdateInlineDraftText,
+  onViewAllComments,
+  tabNameById,
+  username,
+}: CommentDrawerMobileProps) => (
+  <div
+    className={cn(
+      !isMobileDrawerVisible && 'hidden',
+      'fixed h-full flex items-end z-10 inset-0',
+    )}
+    data-comment-drawer-mobile-input
+  >
+    {activeSuggestionDraftCard ? (
+      <MobileSuggestionDraft
+        activeSuggestionDraftCard={activeSuggestionDraftCard}
+        isConnected={isConnected}
+        isDiscardSuggestionOverlayVisible={isDiscardSuggestionOverlayVisible}
+        username={username}
+        onAttemptClose={onAttemptCloseSuggestionDraft}
+        onCancelDiscard={onCancelDiscardSuggestion}
+        onConfirmDiscard={onDiscardSuggestionDraft}
+        onSubmit={onSubmitSuggestionDraft}
+      />
+    ) : isInlineDraftOpen ? (
+      <MobileInlineComment
+        activeDraft={activeDraft}
+        activeDraftId={activeDraftId}
+        isDiscardCommentOverlayVisible={isDiscardCommentOverlayVisible}
+        mobileDraftRef={mobileDraftRef}
+        onAttemptClose={onAttemptCloseNewComment}
+        onCancelDiscard={onCancelDiscardComment}
+        onConfirmDiscard={onCloseDrawer}
+        onSubmit={onCreateComment}
+        onUpdateDraftText={onUpdateInlineDraftText}
+      />
+    ) : (
+      <div
+        data-mobile-comment-drawer-sheet
+        className="h-[456px] max-h-[80dvh] shadow-[0_-12px_32px_rgba(0,0,0,0.18)] rounded-t-[12px]  p-4 w-full color-bg-secondary flex flex-col"
+      >
+        {isCommentMobileFocused ? (
+          <div className="flex justify-between items-center">
+            <button
+              type="button"
+              onClick={onViewAllComments}
+              className="text-heading-sm"
+            >
+              View all
+            </button>
+            <div className="flex items-center gap-[8px]">
+              <IconButton
+                icon={'ChevronLeft'}
+                variant={'ghost'}
+                onClick={
+                  canGoToPreviousMobileComment
+                    ? onPreviousMobileComment
+                    : undefined
+                }
+                className="!min-h-[30px] !h-[30px] !w-[30px] !min-w-[30px]"
+              />
+              <p className="text-heading-sm color-text-default">
+                {mobileFocusedCommentIndex + 1} of {mobileActiveCommentsCount}
+              </p>
+              <IconButton
+                icon={'ChevronRight'}
+                variant={'ghost'}
+                onClick={
+                  canGoToNextMobileComment ? onNextMobileComment : undefined
+                }
+                className="!min-h-[30px] !h-[30px] !w-[30px] !min-w-[30px]"
+              />
+            </div>
+
+            <IconButton
+              icon={'X'}
+              variant="ghost"
+              size="md"
+              onClick={onCloseDrawer}
+            />
+          </div>
+        ) : (
+          <div className="flex justify-between items-center">
+            <h2 className="text-heading-sm">All Comments</h2>
+            <div className="flex gap-sm">
+              <IconButton
+                disabled={!isConnected || isCollaborationEnabled}
+                icon={'MessageSquarePlus'}
+                onClick={onStartNewMobileComment}
+                variant="ghost"
+                size="md"
+              />
+              <IconButton
+                icon={'X'}
+                variant="ghost"
+                size="md"
+                onClick={onCloseDrawer}
+              />
+            </div>
+          </div>
+        )}
+
+        <div
+          className={cn(
+            'mt-4 overflow-hidden',
+            !isConnected ? 'flex items-center justify-center h-full' : 'flex-1',
+          )}
+        >
+          <CommentSection
+            activeCommentId={activeCommentId}
+            isNavbarVisible={isNavbarVisible}
+            isPresentationMode={isPresentationMode}
+            isMobile
+            comments={comments}
+            commentType="all"
+            tabNameById={tabNameById}
+            onCommentFocus={onCommentFocus}
+            showNewCommentInput={false}
+            isCollaborationEnabled={isCollaborationEnabled}
+          />
+        </div>
+      </div>
+    )}
+  </div>
+);

--- a/package/components/inline-comment/comment-drawer.tsx
+++ b/package/components/inline-comment/comment-drawer.tsx
@@ -434,7 +434,7 @@ export const CommentDrawer = ({
               {!isConnected ? (
                 <FloatingAuthPrompt />
               ) : (
-                <div className="border flex flex-col px-[12px] py-[8px] gap-[12px] rounded-[4px] color-bg-default">
+                <div className="flex flex-col gap-[8px]">
                   <div className="flex items-center gap-2">
                     <Avatar
                       src={
@@ -464,7 +464,7 @@ export const CommentDrawer = ({
                     </span>
                   </div>
 
-                  <div className="text-body-sm color-text-default break-words">
+                  <div className="text-body-sm color-text-default ml-[32px] break-words">
                     {suggestionType === 'add' && (
                       <p>
                         <span className="font-semibold">Add:</span>{' '}

--- a/package/components/inline-comment/comment-drawer.tsx
+++ b/package/components/inline-comment/comment-drawer.tsx
@@ -3,6 +3,7 @@ import {
   DynamicDrawerV2,
   IconButton,
   Avatar,
+  Button,
   TextAreaFieldV2,
   SelectTrigger,
   Select,
@@ -21,6 +22,12 @@ import { DEFAULT_TAB_ID, DEFAULT_TAB_NAME } from '../tabs/utils/tab-utils';
 import { useCommentRefs } from '../../stores/comment-store-provider';
 import { resizeInlineCommentTextarea } from './resize-inline-comment-textarea';
 import { clearMobileCommentDrawerCanvasOffset } from '../../utils/comment-scroll-into-view';
+import { FloatingAuthPrompt } from './floating-comment/floating-auth-prompt';
+import { useEnsStatus } from './use-ens-status';
+import EnsLogo from '../../assets/ens.svg';
+import { dateFormatter, nameFormatter } from '../../utils/helpers';
+import verifiedMark from '../../assets/ens-check.svg';
+import type { SuggestionFloatingDraftCard } from './context/types';
 
 const ALL_TABS_OPTION_ID = '__all_tabs__';
 
@@ -42,17 +49,37 @@ export const CommentDrawer = ({
   const activeDraft = useCommentStore((s) =>
     s.activeDraftId ? (s.inlineDrafts[s.activeDraftId] ?? null) : null,
   );
+  const activeSuggestionDraftCard = useCommentStore(
+    (s) =>
+      s.floatingCards.find(
+        (card): card is SuggestionFloatingDraftCard =>
+          card.type === 'suggestion-draft' && card.isFocused,
+      ) ??
+      s.floatingCards.find(
+        (card): card is SuggestionFloatingDraftCard =>
+          card.type === 'suggestion-draft',
+      ) ??
+      null,
+  );
   const createFloatingDraft = useCommentStore((s) => s.createFloatingDraft);
+  const discardDraft = useCommentStore((s) => s.discardDraft);
   const focusCommentInEditor = useCommentStore((s) => s.focusCommentInEditor);
   const isCommentOpen = useCommentStore((s) => s.isCommentOpen);
   const openReplyId = useCommentStore((s) => s.openReplyId);
   const setOpenReplyId = useCommentStore((s) => s.setOpenReplyId);
   const setIsCommentOpen = useCommentStore((s) => s.setIsCommentOpen);
+  const setCommentDrawerOpen = useCommentStore((s) => s.setCommentDrawerOpen);
+  const submitDraft = useCommentStore((s) => s.submitDraft);
   const submitInlineDraft = useCommentStore((s) => s.submitInlineDraft);
   const updateInlineDraftText = useCommentStore((s) => s.updateInlineDraftText);
+  const username = useCommentStore((s) => s.username);
   const { isBelow1280px } = useResponsive();
   const [isDiscardCommentOverlayVisible, setIsDiscardCommentOverlayVisible] =
     useState(false);
+  const [
+    isDiscardSuggestionOverlayVisible,
+    setIsDiscardSuggestionOverlayVisible,
+  ] = useState(false);
   const [pendingCommentFocus, setPendingCommentFocus] = useState<{
     commentId: string;
     tabId: string;
@@ -60,7 +87,10 @@ export const CommentDrawer = ({
   const mobileDrawerRef = useRef<HTMLDivElement | null>(null);
   const mobileDraftTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const { mobileDraftRef } = useCommentRefs();
+  const ensStatus = useEnsStatus(username);
   const isCommentMobileFocused = isBelow1280px && Boolean(openReplyId);
+  const isSuggestionDraftOpen = activeSuggestionDraftCard !== null;
+  const isMobileDrawerVisible = isOpen || isSuggestionDraftOpen;
   // Drawer new-comment state is derived from shared draft state so mobile and desktop
   // follow the same draft lifecycle instead of shadowing it with local UI state.
   const isInlineDraftOpen =
@@ -75,6 +105,11 @@ export const CommentDrawer = ({
   useEscapeKey(() => {
     if (isInlineDraftOpen) {
       setIsDiscardCommentOverlayVisible(true);
+      return;
+    }
+
+    if (isBelow1280px && activeSuggestionDraftCard) {
+      setIsDiscardSuggestionOverlayVisible(true);
       return;
     }
 
@@ -196,6 +231,12 @@ export const CommentDrawer = ({
   }, [isInlineDraftOpen, isOpen]);
 
   useEffect(() => {
+    if (!activeSuggestionDraftCard) {
+      setIsDiscardSuggestionOverlayVisible(false);
+    }
+  }, [activeSuggestionDraftCard]);
+
+  useEffect(() => {
     // Keep the canvas lift scoped to the one state that actually needs it:
     // a focused mobile thread with the drawer sheet covering the viewport.
     if (
@@ -253,9 +294,14 @@ export const CommentDrawer = ({
     setIsDiscardCommentOverlayVisible(true);
   };
 
+  const handleAttemptCloseSuggestionDraft = () => {
+    setIsDiscardSuggestionOverlayVisible(true);
+  };
+
   const handleCloseDrawer = () => {
     setOpenReplyId(null);
     setIsDiscardCommentOverlayVisible(false);
+    setIsDiscardSuggestionOverlayVisible(false);
     setPendingCommentFocus(null);
     setIsCommentOpen(false);
     onClose();
@@ -272,6 +318,26 @@ export const CommentDrawer = ({
 
     // Submit the shared draft record instead of reading live editor selection.
     submitInlineDraft(activeDraftId);
+  };
+
+  const handleSubmitSuggestionDraft = () => {
+    if (!activeSuggestionDraftCard) {
+      return;
+    }
+
+    setIsDiscardSuggestionOverlayVisible(false);
+    submitDraft(activeSuggestionDraftCard.suggestionId);
+    setOpenReplyId(null);
+    setCommentDrawerOpen?.(true);
+  };
+
+  const handleDiscardSuggestionDraft = () => {
+    if (!activeSuggestionDraftCard) {
+      return;
+    }
+
+    setIsDiscardSuggestionOverlayVisible(false);
+    discardDraft(activeSuggestionDraftCard.suggestionId);
   };
 
   const handleStartNewMobileComment = () => {
@@ -324,17 +390,139 @@ export const CommentDrawer = ({
     focusMobileComment(mobileFocusedCommentIndex + 1);
   };
 
+  const hasSuggestionOriginal = Boolean(
+    activeSuggestionDraftCard?.selectedText,
+  );
+  const hasSuggestionInserted = Boolean(
+    activeSuggestionDraftCard?.insertedText,
+  );
+  const canSubmitSuggestion = hasSuggestionOriginal || hasSuggestionInserted;
+  const suggestionType = hasSuggestionOriginal
+    ? hasSuggestionInserted
+      ? 'replace'
+      : 'delete'
+    : hasSuggestionInserted
+      ? 'add'
+      : null;
+
   return (
     <div ref={mobileDrawerRef} data-testid="comment-drawer">
       {isBelow1280px ? (
         <div
           className={cn(
-            !isOpen && 'hidden',
+            !isMobileDrawerVisible && 'hidden',
             'fixed h-full flex items-end z-10 inset-0',
           )}
           data-comment-drawer-mobile-input
         >
-          {isInlineDraftOpen ? (
+          {activeSuggestionDraftCard ? (
+            <div
+              data-mobile-comment-drawer-sheet
+              className="p-4 rounded-t-[12px] shadow-[0_-12px_32px_rgba(0,0,0,0.18)] w-full color-bg-secondary"
+            >
+              <div className="flex justify-between mb-[16px] items-center">
+                <h2 className="text-heading-sm">New Suggestion</h2>
+                <div className="flex gap-sm">
+                  <IconButton
+                    onClick={handleAttemptCloseSuggestionDraft}
+                    icon={'X'}
+                    variant="ghost"
+                    size="md"
+                  />
+                </div>
+              </div>
+              {!isConnected ? (
+                <FloatingAuthPrompt />
+              ) : (
+                <div className="border flex flex-col px-[12px] py-[8px] gap-[12px] rounded-[4px] color-bg-default">
+                  <div className="flex items-center gap-2">
+                    <Avatar
+                      src={
+                        ensStatus.isEns
+                          ? EnsLogo
+                          : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
+                              ensStatus.name,
+                            )}`
+                      }
+                      size="sm"
+                      className="min-w-6"
+                    />
+                    <span className="text-body-sm-bold inline-flex items-center gap-1 min-w-0">
+                      <span className="truncate">
+                        {nameFormatter(ensStatus.name)}
+                      </span>
+                      {ensStatus.isEns && (
+                        <img
+                          src={verifiedMark}
+                          alt="verified"
+                          className="w-3.5 h-3.5"
+                        />
+                      )}
+                    </span>
+                    <span className="text-helper-text-sm color-text-secondary whitespace-nowrap">
+                      {dateFormatter(Date.now())}
+                    </span>
+                  </div>
+
+                  <div className="text-body-sm color-text-default break-words">
+                    {suggestionType === 'add' && (
+                      <p>
+                        <span className="font-semibold">Add:</span>{' '}
+                        <span>
+                          &ldquo;{activeSuggestionDraftCard.insertedText}&rdquo;
+                        </span>
+                      </p>
+                    )}
+                    {suggestionType === 'delete' && (
+                      <p>
+                        <span className="font-semibold">Delete:</span>{' '}
+                        <span className="line-through">
+                          &ldquo;{activeSuggestionDraftCard.selectedText}&rdquo;
+                        </span>
+                      </p>
+                    )}
+                    {suggestionType === 'replace' && (
+                      <p>
+                        <span className="font-semibold">Replace:</span>{' '}
+                        <span className="line-through">
+                          &ldquo;{activeSuggestionDraftCard.selectedText}&rdquo;
+                        </span>{' '}
+                        <span className="font-semibold">with</span>{' '}
+                        <span>
+                          &ldquo;{activeSuggestionDraftCard.insertedText}&rdquo;
+                        </span>
+                      </p>
+                    )}
+                    {!suggestionType && (
+                      <p className="color-text-secondary italic">
+                        Start typing to suggest a change
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex items-center justify-end">
+                    <Button
+                      size="sm"
+                      disabled={!canSubmitSuggestion}
+                      onClick={handleSubmitSuggestionDraft}
+                      className="!min-w-[80px]"
+                    >
+                      Submit
+                    </Button>
+                  </div>
+                </div>
+              )}
+              <DeleteConfirmOverlay
+                isVisible={isDiscardSuggestionOverlayVisible}
+                title="Discard suggestion"
+                heading="Discard suggestion"
+                description="This action will discard your suggestion."
+                confirmLabel="Discard"
+                onCancel={() => setIsDiscardSuggestionOverlayVisible(false)}
+                onConfirm={handleDiscardSuggestionDraft}
+              />
+            </div>
+          ) : isInlineDraftOpen ? (
             <div
               ref={mobileDraftRef}
               data-mobile-comment-drawer-sheet

--- a/package/components/inline-comment/comment-drawer.tsx
+++ b/package/components/inline-comment/comment-drawer.tsx
@@ -26,6 +26,9 @@ export const CommentDrawer = ({
   const comments = useCommentStore((s) => s.initialComments);
   const isConnected = useCommentStore((s) => s.isConnected);
   const focusCommentInEditor = useCommentStore((s) => s.focusCommentInEditor);
+  const focusSuggestionDraftInEditor = useCommentStore(
+    (s) => s.focusSuggestionDraftInEditor,
+  );
   const isCommentOpen = useCommentStore((s) => s.isCommentOpen);
   const openReplyId = useCommentStore((s) => s.openReplyId);
   const setOpenReplyId = useCommentStore((s) => s.setOpenReplyId);
@@ -156,6 +159,13 @@ export const CommentDrawer = ({
           onCommentFocus={handleCommentFocus}
           onCreateComment={handleCreateComment}
           onDiscardSuggestionDraft={handleDiscardSuggestionDraft}
+          onFocusSuggestionDraft={() => {
+            if (activeSuggestionDraftCard) {
+              focusSuggestionDraftInEditor(
+                activeSuggestionDraftCard.suggestionId,
+              );
+            }
+          }}
           onNextMobileComment={handleNextMobileComment}
           onPreviousMobileComment={handlePreviousMobileComment}
           onStartNewMobileComment={handleStartNewMobileComment}

--- a/package/components/inline-comment/comment-drawer.tsx
+++ b/package/components/inline-comment/comment-drawer.tsx
@@ -1,35 +1,15 @@
-import { useEffect, useRef, useState } from 'react';
-import {
-  DynamicDrawerV2,
-  IconButton,
-  Avatar,
-  Button,
-  TextAreaFieldV2,
-  SelectTrigger,
-  Select,
-  SelectContent,
-  SelectValue,
-  SelectItem,
-} from '@fileverse/ui';
-import cn from 'classnames';
+import { useRef } from 'react';
 import { CommentDrawerProps } from './types';
-import { CommentSection } from './comment-section';
-import { DeleteConfirmOverlay } from './delete-confirm-overlay';
 import { useCommentStore } from '../../stores/comment-store';
 import { useResponsive } from '../../utils/responsive';
-import { useEscapeKey } from '../../hooks/useEscapeKey';
-import { DEFAULT_TAB_ID, DEFAULT_TAB_NAME } from '../tabs/utils/tab-utils';
 import { useCommentRefs } from '../../stores/comment-store-provider';
-import { resizeInlineCommentTextarea } from './resize-inline-comment-textarea';
-import { clearMobileCommentDrawerCanvasOffset } from '../../utils/comment-scroll-into-view';
-import { FloatingAuthPrompt } from './floating-comment/floating-auth-prompt';
-import { useEnsStatus } from './use-ens-status';
-import EnsLogo from '../../assets/ens.svg';
-import { dateFormatter, nameFormatter } from '../../utils/helpers';
-import verifiedMark from '../../assets/ens-check.svg';
-import type { SuggestionFloatingDraftCard } from './context/types';
-
-const ALL_TABS_OPTION_ID = '__all_tabs__';
+import { CommentDrawerDesktop } from './comment-drawer-desktop';
+import { CommentDrawerMobile } from './comment-drawer-mobile';
+import { useCommentDrawerDrafts } from './use-comment-drawer-drafts';
+import { useCommentDrawerFilters } from './use-comment-drawer-filters';
+import { useCommentDrawerFocus } from './use-comment-drawer-focus';
+import { useCommentDrawerLifecycle } from './use-comment-drawer-lifecycle';
+import { useMobileCommentNavigation } from './use-mobile-comment-navigation';
 
 export const CommentDrawer = ({
   isOpen,
@@ -45,720 +25,173 @@ export const CommentDrawer = ({
 }: CommentDrawerProps) => {
   const comments = useCommentStore((s) => s.initialComments);
   const isConnected = useCommentStore((s) => s.isConnected);
-  const activeDraftId = useCommentStore((s) => s.activeDraftId);
-  const activeDraft = useCommentStore((s) =>
-    s.activeDraftId ? (s.inlineDrafts[s.activeDraftId] ?? null) : null,
-  );
-  const activeSuggestionDraftCard = useCommentStore(
-    (s) =>
-      s.floatingCards.find(
-        (card): card is SuggestionFloatingDraftCard =>
-          card.type === 'suggestion-draft' && card.isFocused,
-      ) ??
-      s.floatingCards.find(
-        (card): card is SuggestionFloatingDraftCard =>
-          card.type === 'suggestion-draft',
-      ) ??
-      null,
-  );
-  const createFloatingDraft = useCommentStore((s) => s.createFloatingDraft);
-  const discardDraft = useCommentStore((s) => s.discardDraft);
   const focusCommentInEditor = useCommentStore((s) => s.focusCommentInEditor);
   const isCommentOpen = useCommentStore((s) => s.isCommentOpen);
   const openReplyId = useCommentStore((s) => s.openReplyId);
   const setOpenReplyId = useCommentStore((s) => s.setOpenReplyId);
   const setIsCommentOpen = useCommentStore((s) => s.setIsCommentOpen);
-  const setCommentDrawerOpen = useCommentStore((s) => s.setCommentDrawerOpen);
-  const submitDraft = useCommentStore((s) => s.submitDraft);
-  const submitInlineDraft = useCommentStore((s) => s.submitInlineDraft);
-  const updateInlineDraftText = useCommentStore((s) => s.updateInlineDraftText);
   const username = useCommentStore((s) => s.username);
   const { isBelow1280px } = useResponsive();
-  const [isDiscardCommentOverlayVisible, setIsDiscardCommentOverlayVisible] =
-    useState(false);
-  const [
-    isDiscardSuggestionOverlayVisible,
-    setIsDiscardSuggestionOverlayVisible,
-  ] = useState(false);
-  const [pendingCommentFocus, setPendingCommentFocus] = useState<{
-    commentId: string;
-    tabId: string;
-  } | null>(null);
   const mobileDrawerRef = useRef<HTMLDivElement | null>(null);
-  const mobileDraftTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const { mobileDraftRef } = useCommentRefs();
-  const ensStatus = useEnsStatus(username);
   const isCommentMobileFocused = isBelow1280px && Boolean(openReplyId);
-  const isSuggestionDraftOpen = activeSuggestionDraftCard !== null;
-  const isMobileDrawerVisible = isOpen || isSuggestionDraftOpen;
-  // Drawer new-comment state is derived from shared draft state so mobile and desktop
-  // follow the same draft lifecycle instead of shadowing it with local UI state.
-  const isInlineDraftOpen =
-    isCommentOpen &&
-    activeDraft !== null &&
-    activeDraftId !== null &&
-    activeDraft.location === 'drawer' &&
-    // Auth-pending drafts intentionally fall back to the non-draft drawer route so
-    // mobile can show the auth screen without discarding the tracked draft.
-    !activeDraft.isAuthPending;
-
-  useEscapeKey(() => {
-    if (isInlineDraftOpen) {
-      setIsDiscardCommentOverlayVisible(true);
-      return;
-    }
-
-    if (isBelow1280px && activeSuggestionDraftCard) {
-      setIsDiscardSuggestionOverlayVisible(true);
-      return;
-    }
-
-    onClose();
-  });
-
-  const commentTypeOptions = [
-    { id: 'all', label: 'All types' },
-    { id: 'active', label: 'Active' },
-    { id: 'resolved', label: 'Resolved' },
-  ];
-
-  const resolvedTabs =
-    tabs.length > 0
-      ? tabs
-      : [{ id: DEFAULT_TAB_ID, name: DEFAULT_TAB_NAME, emoji: null }];
-  const tabList = [
-    { id: ALL_TABS_OPTION_ID, label: 'All tabs' },
-    ...resolvedTabs.map((tabOption) => ({
-      id: tabOption.id,
-      label: tabOption.name,
-    })),
-  ];
-  const tabNameById = Object.fromEntries(
-    resolvedTabs.map((tabOption) => [tabOption.id, tabOption.name]),
-  );
-  const [commentType, setCommentType] = useState('active');
-  const [tab, setTab] = useState(ALL_TABS_OPTION_ID);
-  const [isCommentTypeSelectOpen, setIsCommentTypeSelectOpen] = useState(false);
-  const [isTabSelectOpen, setIsTabSelectOpen] = useState(false);
-  const selectedCommentTabId = tab === ALL_TABS_OPTION_ID ? activeTabId : tab;
-  const selectedTabLabel =
-    tabList.find((tabOption) => tabOption.id === tab)?.label ??
-    DEFAULT_TAB_NAME;
-
-  const filteredComments = comments.filter((comment) => {
-    const commentTabId = comment.tabId || DEFAULT_TAB_ID;
-    const matchesTab = tab === ALL_TABS_OPTION_ID || commentTabId === tab;
-
-    if (!matchesTab || comment.deleted) {
-      return false;
-    }
-
-    if (commentType === 'active') {
-      return !comment.resolved;
-    }
-
-    if (commentType === 'resolved') {
-      return Boolean(comment.resolved);
-    }
-
-    return true;
-  });
-
-  const sectionLabel =
-    commentType === 'resolved'
-      ? 'Resolved'
-      : commentType === 'all'
-        ? 'All comments'
-        : 'Active';
-  const mobileActiveComments = comments
-    .filter((comment) => !comment.deleted)
-    .sort(
-      (a, b) =>
-        new Date(b.createdAt || 0).getTime() -
-        new Date(a.createdAt || 0).getTime(),
-    );
-  const mobileFocusedCommentIndex = mobileActiveComments.findIndex(
-    (comment) => comment.id === openReplyId,
-  );
-  const canGoToPreviousMobileComment = mobileFocusedCommentIndex > 0;
-  const canGoToNextMobileComment =
-    mobileFocusedCommentIndex >= 0 &&
-    mobileFocusedCommentIndex < mobileActiveComments.length - 1;
-
-  const handleTabChange = (nextTab: string) => {
-    setTab(nextTab);
-  };
-
-  const handleCommentTypeSelectOpenChange = (open: boolean) => {
-    setIsCommentTypeSelectOpen(open);
-
-    if (open) {
-      setIsTabSelectOpen(false);
-    }
-  };
-
-  const handleTabSelectOpenChange = (open: boolean) => {
-    setIsTabSelectOpen(open);
-
-    if (open) {
-      setIsCommentTypeSelectOpen(false);
-    }
-  };
-
-  const handleCommentFocus = (commentId: string, commentTabId?: string) => {
-    const targetTabId = commentTabId || DEFAULT_TAB_ID;
-
-    if (targetTabId !== activeTabId) {
-      // Cross-tab thread clicks should not silently no-op. Switch tabs first,
-      // then replay the requested focus once the target tab is active.
-      setPendingCommentFocus({ commentId, tabId: targetTabId });
-      onTabChange?.(targetTabId);
-      return;
-    }
-
-    focusCommentInEditor(
-      commentId,
-      isBelow1280px ? undefined : { source: 'explicit-ui' },
-    );
-  };
-
-  useEffect(() => {
-    if (!isOpen && !isInlineDraftOpen) {
-      setIsDiscardCommentOverlayVisible(false);
-      setIsCommentTypeSelectOpen(false);
-      setIsTabSelectOpen(false);
-    }
-  }, [isInlineDraftOpen, isOpen]);
-
-  useEffect(() => {
-    if (!activeSuggestionDraftCard) {
-      setIsDiscardSuggestionOverlayVisible(false);
-    }
-  }, [activeSuggestionDraftCard]);
-
-  useEffect(() => {
-    // Keep the canvas lift scoped to the one state that actually needs it:
-    // a focused mobile thread with the drawer sheet covering the viewport.
-    if (
-      isBelow1280px &&
-      isOpen &&
-      isCommentMobileFocused &&
-      !isInlineDraftOpen
-    ) {
-      return () => {
-        clearMobileCommentDrawerCanvasOffset();
-      };
-    }
-
-    clearMobileCommentDrawerCanvasOffset();
-    return () => {
-      clearMobileCommentDrawerCanvasOffset();
-    };
-  }, [isBelow1280px, isCommentMobileFocused, isInlineDraftOpen, isOpen]);
-
-  useEffect(() => {
-    if (
-      !pendingCommentFocus ||
-      pendingCommentFocus.tabId !== activeTabId ||
-      !comments.some(
-        (comment) =>
-          comment.id === pendingCommentFocus.commentId &&
-          (comment.tabId || DEFAULT_TAB_ID) === activeTabId,
-      )
-    ) {
-      return;
-    }
-
-    const frameId = window.requestAnimationFrame(() => {
-      // Wait a frame so the tab switch can mount the matching comment nodes
-      // before trying to focus/scroll them in the editor.
-      setOpenReplyId(pendingCommentFocus.commentId);
-      focusCommentInEditor(
-        pendingCommentFocus.commentId,
-        isBelow1280px ? undefined : { source: 'explicit-ui' },
-      );
-      setPendingCommentFocus(null);
+  const {
+    closeFilterSelects,
+    commentType,
+    commentTypeOptions,
+    filteredComments,
+    handleCommentTypeSelectOpenChange,
+    handleTabSelectOpenChange,
+    isCommentTypeSelectOpen,
+    isTabSelectOpen,
+    resetFilters,
+    sectionLabel,
+    selectedCommentTabId,
+    selectedTab,
+    selectedTabLabel,
+    setCommentType,
+    setTab,
+    tabList,
+    tabNameById,
+  } = useCommentDrawerFilters({ activeTabId, comments, tabs });
+  const {
+    activeDraft,
+    activeDraftId,
+    activeSuggestionDraftCard,
+    handleCreateComment,
+    handleDiscardSuggestionDraft,
+    handleStartNewMobileComment,
+    handleSubmitSuggestionDraft,
+    isDiscardCommentOverlayVisible,
+    isDiscardSuggestionOverlayVisible,
+    isInlineDraftOpen,
+    setIsDiscardCommentOverlayVisible,
+    setIsDiscardSuggestionOverlayVisible,
+    updateInlineDraftText,
+  } = useCommentDrawerDrafts({ selectedCommentTabId, setOpenReplyId });
+  const isDrawerInlineDraftOpen = isCommentOpen && isInlineDraftOpen;
+  const isMobileDrawerVisible = isOpen || activeSuggestionDraftCard !== null;
+  const { clearPendingCommentFocus, handleCommentFocus } =
+    useCommentDrawerFocus({
+      activeTabId,
+      comments,
+      focusCommentInEditor,
+      isBelow1280px,
+      onTabChange,
+      setOpenReplyId,
     });
-
-    return () => window.cancelAnimationFrame(frameId);
-  }, [
-    activeTabId,
+  const {
+    canGoToNextMobileComment,
+    canGoToPreviousMobileComment,
+    handleNextMobileComment,
+    handlePreviousMobileComment,
+    handleViewAllComments,
+    mobileActiveCommentsCount,
+    mobileFocusedCommentIndex,
+  } = useMobileCommentNavigation({
     comments,
-    focusCommentInEditor,
-    isBelow1280px,
-    pendingCommentFocus,
+    mobileDrawerRef,
+    onCommentFocus: handleCommentFocus,
+    openReplyId,
     setOpenReplyId,
-  ]);
+  });
 
-  const handleAttemptCloseNewComment = () => {
-    setIsDiscardCommentOverlayVisible(true);
-  };
-
-  const handleAttemptCloseSuggestionDraft = () => {
-    setIsDiscardSuggestionOverlayVisible(true);
-  };
+  useCommentDrawerLifecycle({
+    activeSuggestionDraftCard,
+    closeFilterSelects,
+    isBelow1280px,
+    isCommentMobileFocused,
+    isInlineDraftOpen: isDrawerInlineDraftOpen,
+    isOpen,
+    onClose,
+    setIsDiscardCommentOverlayVisible,
+    setIsDiscardSuggestionOverlayVisible,
+  });
 
   const handleCloseDrawer = () => {
     setOpenReplyId(null);
     setIsDiscardCommentOverlayVisible(false);
     setIsDiscardSuggestionOverlayVisible(false);
-    setPendingCommentFocus(null);
+    clearPendingCommentFocus();
     setIsCommentOpen(false);
     onClose();
   };
 
-  const handleViewAllComments = () => {
-    setOpenReplyId(null);
-  };
-
-  const handleCreateComment = () => {
-    if (!activeDraftId) {
-      return;
-    }
-
-    // Submit the shared draft record instead of reading live editor selection.
-    submitInlineDraft(activeDraftId);
-  };
-
-  const handleSubmitSuggestionDraft = () => {
-    if (!activeSuggestionDraftCard) {
-      return;
-    }
-
-    setIsDiscardSuggestionOverlayVisible(false);
-    submitDraft(activeSuggestionDraftCard.suggestionId);
-    setOpenReplyId(null);
-    setCommentDrawerOpen?.(true);
-  };
-
-  const handleDiscardSuggestionDraft = () => {
-    if (!activeSuggestionDraftCard) {
-      return;
-    }
-
-    setIsDiscardSuggestionOverlayVisible(false);
-    discardDraft(activeSuggestionDraftCard.suggestionId);
-  };
-
-  const handleStartNewMobileComment = () => {
-    // The mobile drawer supports top-level comments
-    // Keep this drawer-scoped so floating inline comments remain
-    // anchored to an explicit editor range.
-    createFloatingDraft({
-      location: 'drawer',
-      allowEmptySelection: true,
-      tabId: selectedCommentTabId,
-    });
-  };
-
-  const focusMobileComment = (commentIndex: number) => {
-    const targetComment = mobileActiveComments[commentIndex];
-
-    if (!targetComment?.id) {
-      return;
-    }
-
-    setOpenReplyId(targetComment.id);
-    handleCommentFocus(targetComment.id, targetComment.tabId);
-
-    requestAnimationFrame(() => {
-      const commentElement =
-        mobileDrawerRef.current?.querySelector<HTMLElement>(
-          `[data-comment-id="${targetComment.id}"]`,
-        );
-
-      commentElement?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-      });
-    });
-  };
-
-  const handlePreviousMobileComment = () => {
-    if (!canGoToPreviousMobileComment) {
-      return;
-    }
-
-    focusMobileComment(mobileFocusedCommentIndex - 1);
-  };
-
-  const handleNextMobileComment = () => {
-    if (!canGoToNextMobileComment) {
-      return;
-    }
-
-    focusMobileComment(mobileFocusedCommentIndex + 1);
-  };
-
-  const hasSuggestionOriginal = Boolean(
-    activeSuggestionDraftCard?.selectedText,
-  );
-  const hasSuggestionInserted = Boolean(
-    activeSuggestionDraftCard?.insertedText,
-  );
-  const canSubmitSuggestion = hasSuggestionOriginal || hasSuggestionInserted;
-  const suggestionType = hasSuggestionOriginal
-    ? hasSuggestionInserted
-      ? 'replace'
-      : 'delete'
-    : hasSuggestionInserted
-      ? 'add'
-      : null;
-
   return (
     <div ref={mobileDrawerRef} data-testid="comment-drawer">
       {isBelow1280px ? (
-        <div
-          className={cn(
-            !isMobileDrawerVisible && 'hidden',
-            'fixed h-full flex items-end z-10 inset-0',
-          )}
-          data-comment-drawer-mobile-input
-        >
-          {activeSuggestionDraftCard ? (
-            <div
-              data-mobile-comment-drawer-sheet
-              className="p-4 rounded-t-[12px] shadow-[0_-12px_32px_rgba(0,0,0,0.18)] w-full color-bg-secondary"
-            >
-              <div className="flex justify-between mb-[16px] items-center">
-                <h2 className="text-heading-sm">New Suggestion</h2>
-                <div className="flex gap-sm">
-                  <IconButton
-                    onClick={handleAttemptCloseSuggestionDraft}
-                    icon={'X'}
-                    variant="ghost"
-                    size="md"
-                  />
-                </div>
-              </div>
-              {!isConnected ? (
-                <FloatingAuthPrompt />
-              ) : (
-                <div className="flex flex-col gap-[8px]">
-                  <div className="flex items-center gap-2">
-                    <Avatar
-                      src={
-                        ensStatus.isEns
-                          ? EnsLogo
-                          : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
-                              ensStatus.name,
-                            )}`
-                      }
-                      size="sm"
-                      className="min-w-6"
-                    />
-                    <span className="text-body-sm-bold inline-flex items-center gap-1 min-w-0">
-                      <span className="truncate">
-                        {nameFormatter(ensStatus.name)}
-                      </span>
-                      {ensStatus.isEns && (
-                        <img
-                          src={verifiedMark}
-                          alt="verified"
-                          className="w-3.5 h-3.5"
-                        />
-                      )}
-                    </span>
-                    <span className="text-helper-text-sm color-text-secondary whitespace-nowrap">
-                      {dateFormatter(Date.now())}
-                    </span>
-                  </div>
-
-                  <div className="text-body-sm color-text-default ml-[32px] break-words">
-                    {suggestionType === 'add' && (
-                      <p>
-                        <span className="font-semibold">Add:</span>{' '}
-                        <span>
-                          &ldquo;{activeSuggestionDraftCard.insertedText}&rdquo;
-                        </span>
-                      </p>
-                    )}
-                    {suggestionType === 'delete' && (
-                      <p>
-                        <span className="font-semibold">Delete:</span>{' '}
-                        <span className="line-through">
-                          &ldquo;{activeSuggestionDraftCard.selectedText}&rdquo;
-                        </span>
-                      </p>
-                    )}
-                    {suggestionType === 'replace' && (
-                      <p>
-                        <span className="font-semibold">Replace:</span>{' '}
-                        <span className="line-through">
-                          &ldquo;{activeSuggestionDraftCard.selectedText}&rdquo;
-                        </span>{' '}
-                        <span className="font-semibold">with</span>{' '}
-                        <span>
-                          &ldquo;{activeSuggestionDraftCard.insertedText}&rdquo;
-                        </span>
-                      </p>
-                    )}
-                    {!suggestionType && (
-                      <p className="color-text-secondary italic">
-                        Start typing to suggest a change
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="flex items-center justify-end">
-                    <Button
-                      size="sm"
-                      disabled={!canSubmitSuggestion}
-                      onClick={handleSubmitSuggestionDraft}
-                      className="!min-w-[80px]"
-                    >
-                      Submit
-                    </Button>
-                  </div>
-                </div>
-              )}
-              <DeleteConfirmOverlay
-                isVisible={isDiscardSuggestionOverlayVisible}
-                title="Discard suggestion"
-                heading="Discard suggestion"
-                description="This action will discard your suggestion."
-                confirmLabel="Discard"
-                onCancel={() => setIsDiscardSuggestionOverlayVisible(false)}
-                onConfirm={handleDiscardSuggestionDraft}
-              />
-            </div>
-          ) : isInlineDraftOpen ? (
-            <div
-              ref={mobileDraftRef}
-              data-mobile-comment-drawer-sheet
-              className="p-4 rounded-t-[12px] shadow-[0_-12px_32px_rgba(0,0,0,0.18)] w-full color-bg-secondary"
-            >
-              <div className="flex justify-between mb-[16px] items-center">
-                <h2 className="text-heading-sm">New Comment</h2>
-                <div className="flex gap-sm">
-                  <IconButton
-                    onClick={handleAttemptCloseNewComment}
-                    icon={'X'}
-                    variant="ghost"
-                    size="md"
-                  />
-                </div>
-              </div>
-              <div className="border flex px-[12px] items-center justify-between py-[8px] gap-[8px] rounded-[4px]">
-                <Avatar
-                  src={`https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
-                    '',
-                  )}`}
-                  className="w-[16px] h-[16px]"
-                />
-                <TextAreaFieldV2
-                  ref={mobileDraftTextareaRef}
-                  value={activeDraft?.text || ''}
-                  autoFocus
-                  onChange={(event) => {
-                    if (activeDraftId) {
-                      updateInlineDraftText(activeDraftId, event.target.value);
-                    }
-
-                    resizeInlineCommentTextarea(event.currentTarget);
-                  }}
-                  onInput={(event) =>
-                    resizeInlineCommentTextarea(event.currentTarget)
-                  }
-                  onKeyDown={(event) => {
-                    if (
-                      event.key === 'Enter' &&
-                      (!event.shiftKey || event.metaKey)
-                    ) {
-                      event.preventDefault();
-                      handleCreateComment();
-                    }
-                  }}
-                  className="color-bg-default w-full text-body-sm color-text-default !p-0 !border-none h-[20px] max-h-[296px] overflow-y-auto no-scrollbar whitespace-pre-wrap"
-                  placeholder="Add a comment"
-                />
-                <IconButton
-                  onClick={handleCreateComment}
-                  icon={'SendHorizontal'}
-                  variant="ghost"
-                  disabled={!activeDraft?.text.trim()}
-                  className="!min-w-[24px] !w-[24px] !min-h-[24px] !h-[24px]"
-                />
-              </div>
-              <DeleteConfirmOverlay
-                isVisible={isDiscardCommentOverlayVisible}
-                title="Discard comment"
-                heading="Discard comment"
-                description="This action will discard your comment."
-                confirmLabel="Discard"
-                onCancel={() => setIsDiscardCommentOverlayVisible(false)}
-                onConfirm={handleCloseDrawer}
-              />
-            </div>
-          ) : (
-            <div
-              data-mobile-comment-drawer-sheet
-              className="h-[456px] max-h-[80dvh] shadow-[0_-12px_32px_rgba(0,0,0,0.18)] rounded-t-[12px]  p-4 w-full color-bg-secondary flex flex-col"
-            >
-              {isCommentMobileFocused ? (
-                <div className="flex justify-between items-center">
-                  <button
-                    type="button"
-                    onClick={handleViewAllComments}
-                    className="text-heading-sm"
-                  >
-                    View all
-                  </button>
-                  <div className="flex items-center gap-[8px]">
-                    <IconButton
-                      icon={'ChevronLeft'}
-                      variant={'ghost'}
-                      onClick={handlePreviousMobileComment}
-                      className="!min-h-[30px] !h-[30px] !w-[30px] !min-w-[30px]"
-                    />
-                    <p className="text-heading-sm color-text-default">
-                      {mobileFocusedCommentIndex + 1} of{' '}
-                      {mobileActiveComments.length}
-                    </p>
-                    <IconButton
-                      icon={'ChevronRight'}
-                      variant={'ghost'}
-                      onClick={handleNextMobileComment}
-                      className="!min-h-[30px] !h-[30px] !w-[30px] !min-w-[30px]"
-                    />
-                  </div>
-
-                  <IconButton
-                    icon={'X'}
-                    variant="ghost"
-                    size="md"
-                    onClick={handleCloseDrawer}
-                  />
-                </div>
-              ) : (
-                <div className="flex justify-between items-center">
-                  <h2 className="text-heading-sm">All Comments</h2>
-                  <div className="flex gap-sm">
-                    <IconButton
-                      disabled={!isConnected || isCollaborationEnabled}
-                      icon={'MessageSquarePlus'}
-                      onClick={handleStartNewMobileComment}
-                      variant="ghost"
-                      size="md"
-                    />
-                    <IconButton
-                      icon={'X'}
-                      variant="ghost"
-                      size="md"
-                      onClick={handleCloseDrawer}
-                    />
-                  </div>
-                </div>
-              )}
-
-              <div
-                className={cn(
-                  'mt-4 overflow-hidden',
-                  !isConnected
-                    ? 'flex items-center justify-center h-full'
-                    : 'flex-1',
-                )}
-              >
-                <CommentSection
-                  activeCommentId={activeCommentId}
-                  isNavbarVisible={isNavbarVisible}
-                  isPresentationMode={isPresentationMode}
-                  isMobile
-                  comments={comments}
-                  commentType="all"
-                  tabNameById={tabNameById}
-                  onCommentFocus={handleCommentFocus}
-                  showNewCommentInput={false}
-                  isCollaborationEnabled={isCollaborationEnabled}
-                />
-              </div>
-            </div>
-          )}
-        </div>
-      ) : (
-        <DynamicDrawerV2
-          open={isOpen}
-          onOpenChange={onClose}
-          side="right"
-          rounded={true}
-          dismissible
-          className={cn(
-            'w-[336px] !z-40 right-0 shadow-elevation-4 rounded-lg border color-border-default',
-            isOpen && 'right-2 md:!right-4',
-            isNavbarVisible
-              ? `h-[calc(98vh-140px)] ${isPreviewMode ? 'top-[4rem]' : 'top-[7.25rem] '}`
-              : 'top-[4rem] h-[calc(100vh-90px)] xl:h-[calc(99vh-90px)]',
-            isPresentationMode && 'h-[calc(100vh-5rem)] top-[4rem] !z-[60]',
-          )}
-          headerClassName="border-b color-border-default !color-bg-default px-4 pb-[12px] !rounded-t-lg"
-          contentClassName="!rounded-lg !px-0 !h-full !pb-5 select-text"
-          title="Comments"
-          content={
-            <div
-              className={cn(
-                'pt-4',
-                !isConnected && isPreviewMode && 'flex items-center h-[77dvh]',
-              )}
-            >
-              {(isConnected || isCollaborationEnabled) && (
-                <div className="flex mb-[16px] px-4 gap-[8px]">
-                  <Select
-                    value={commentType}
-                    open={isCommentTypeSelectOpen}
-                    onOpenChange={handleCommentTypeSelectOpenChange}
-                    onValueChange={setCommentType}
-                  >
-                    <SelectTrigger className="w-[148px]">
-                      <SelectValue placeholder="Active" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {commentTypeOptions.map((option) => (
-                        <SelectItem key={option.id} value={option.id}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Select
-                    value={tab}
-                    open={isTabSelectOpen}
-                    onOpenChange={handleTabSelectOpenChange}
-                    onValueChange={handleTabChange}
-                  >
-                    <SelectTrigger className="w-[148px]">
-                      <SelectValue placeholder="All tabs" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {tabList.map((option) => (
-                        <SelectItem key={option.id} value={option.id}>
-                          {option.label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              )}
-              <CommentSection
-                activeCommentId={activeCommentId}
-                isNavbarVisible={isNavbarVisible}
-                isPresentationMode={isPresentationMode}
-                comments={filteredComments}
-                commentType={commentType as 'all' | 'active' | 'resolved'}
-                sectionLabel={sectionLabel}
-                tabNameById={tabNameById}
-                selectedTabLabel={selectedTabLabel}
-                newCommentTabId={selectedCommentTabId}
-                onCommentFocus={handleCommentFocus}
-                onReset={() => {
-                  // Reset both filters so the empty state can always recover
-                  // to the full drawer list instead of staying tab-scoped.
-                  setCommentType('all');
-                  setTab(ALL_TABS_OPTION_ID);
-                }}
-                isCollaborationEnabled={isCollaborationEnabled}
-              />
-            </div>
+        <CommentDrawerMobile
+          activeCommentId={activeCommentId}
+          activeDraft={activeDraft}
+          activeDraftId={activeDraftId}
+          activeSuggestionDraftCard={activeSuggestionDraftCard}
+          canGoToNextMobileComment={canGoToNextMobileComment}
+          canGoToPreviousMobileComment={canGoToPreviousMobileComment}
+          comments={comments}
+          isCollaborationEnabled={isCollaborationEnabled}
+          isCommentMobileFocused={isCommentMobileFocused}
+          isConnected={isConnected}
+          isDiscardCommentOverlayVisible={isDiscardCommentOverlayVisible}
+          isDiscardSuggestionOverlayVisible={isDiscardSuggestionOverlayVisible}
+          isInlineDraftOpen={isDrawerInlineDraftOpen}
+          isMobileDrawerVisible={isMobileDrawerVisible}
+          isNavbarVisible={isNavbarVisible}
+          isPresentationMode={isPresentationMode}
+          mobileActiveCommentsCount={mobileActiveCommentsCount}
+          mobileDraftRef={mobileDraftRef}
+          mobileFocusedCommentIndex={mobileFocusedCommentIndex}
+          onAttemptCloseNewComment={() =>
+            setIsDiscardCommentOverlayVisible(true)
           }
+          onAttemptCloseSuggestionDraft={() =>
+            setIsDiscardSuggestionOverlayVisible(true)
+          }
+          onCancelDiscardComment={() =>
+            setIsDiscardCommentOverlayVisible(false)
+          }
+          onCancelDiscardSuggestion={() =>
+            setIsDiscardSuggestionOverlayVisible(false)
+          }
+          onCloseDrawer={handleCloseDrawer}
+          onCommentFocus={handleCommentFocus}
+          onCreateComment={handleCreateComment}
+          onDiscardSuggestionDraft={handleDiscardSuggestionDraft}
+          onNextMobileComment={handleNextMobileComment}
+          onPreviousMobileComment={handlePreviousMobileComment}
+          onStartNewMobileComment={handleStartNewMobileComment}
+          onSubmitSuggestionDraft={handleSubmitSuggestionDraft}
+          onUpdateInlineDraftText={updateInlineDraftText}
+          onViewAllComments={handleViewAllComments}
+          tabNameById={tabNameById}
+          username={username}
+        />
+      ) : (
+        <CommentDrawerDesktop
+          activeCommentId={activeCommentId}
+          commentType={commentType}
+          commentTypeOptions={commentTypeOptions}
+          filteredComments={filteredComments}
+          isCollaborationEnabled={isCollaborationEnabled}
+          isCommentTypeSelectOpen={isCommentTypeSelectOpen}
+          isConnected={isConnected}
+          isNavbarVisible={isNavbarVisible}
+          isOpen={isOpen}
+          isPresentationMode={isPresentationMode}
+          isPreviewMode={isPreviewMode}
+          isTabSelectOpen={isTabSelectOpen}
+          newCommentTabId={selectedCommentTabId}
+          onClose={onClose}
+          onCommentFocus={handleCommentFocus}
+          onCommentTypeChange={setCommentType}
+          onCommentTypeSelectOpenChange={handleCommentTypeSelectOpenChange}
+          onReset={resetFilters}
+          onTabChange={setTab}
+          onTabSelectOpenChange={handleTabSelectOpenChange}
+          sectionLabel={sectionLabel}
+          selectedTab={selectedTab}
+          selectedTabLabel={selectedTabLabel}
+          tabList={tabList}
+          tabNameById={tabNameById}
         />
       )}
     </div>

--- a/package/components/inline-comment/comment-floating-layout.ts
+++ b/package/components/inline-comment/comment-floating-layout.ts
@@ -2,6 +2,7 @@
 // Only recalculate what changed and stop once the remaining cards stay the same.
 
 export const FLOATING_COMMENT_CARD_GAP = 8;
+export const FLOATING_COMMENT_BOTTOM_SPACE = 48;
 
 export const enum FloatingLayoutInvalidationFlag {
   None = 0,
@@ -82,6 +83,38 @@ const setHiddenPlacement = (
   });
 };
 
+const getReservedHiddenCardRange = (floatingCard: FloatingCardLayoutInput) => {
+  if (!floatingCard.isMeasured || floatingCard.height <= 0) {
+    return null;
+  }
+
+  const translateY = getLastCommittedTranslateY(floatingCard);
+
+  if (translateY === null) {
+    return null;
+  }
+
+  return {
+    top: translateY,
+    bottom: translateY + floatingCard.height,
+  };
+};
+
+const reserveHiddenCardBottom = (
+  previousBottom: number | null,
+  floatingCard: FloatingCardLayoutInput,
+) => {
+  const reservedRange = getReservedHiddenCardRange(floatingCard);
+
+  if (!reservedRange) {
+    return previousBottom;
+  }
+
+  return previousBottom === null
+    ? reservedRange.bottom
+    : Math.max(previousBottom, reservedRange.bottom);
+};
+
 const computeFocusedFloatingCommentLayout = ({
   floatingCards,
   focusedFloatingCardId,
@@ -123,6 +156,12 @@ const computeFocusedFloatingCommentLayout = ({
 
     if (!canPlaceFloatingCard(floatingCard)) {
       setHiddenPlacement(placements, floatingCard);
+      const reservedRange = getReservedHiddenCardRange(floatingCard);
+
+      if (reservedRange) {
+        nextTop = Math.min(nextTop, reservedRange.top);
+      }
+
       continue;
     }
 
@@ -155,6 +194,8 @@ const computeFocusedFloatingCommentLayout = ({
 
     if (!canPlaceFloatingCard(floatingCard)) {
       setHiddenPlacement(placements, floatingCard);
+      previousBottom =
+        reserveHiddenCardBottom(previousBottom, floatingCard) ?? previousBottom;
       continue;
     }
 
@@ -228,6 +269,7 @@ export const computeFloatingCommentLayout = ({
     // If the card cannot be shown, keep its last position but hide it.
     if (!canPlaceFloatingCard(floatingCard)) {
       setHiddenPlacement(placements, floatingCard);
+      previousBottom = reserveHiddenCardBottom(previousBottom, floatingCard);
       continue;
     }
     // Before the restart point, keep the saved position.

--- a/package/components/inline-comment/comment-floating-layout.ts
+++ b/package/components/inline-comment/comment-floating-layout.ts
@@ -3,6 +3,7 @@
 
 export const FLOATING_COMMENT_CARD_GAP = 8;
 export const FLOATING_COMMENT_BOTTOM_SPACE = 48;
+export const FLOATING_COMMENT_RIGHT_SPACE = 48;
 
 export const enum FloatingLayoutInvalidationFlag {
   None = 0,

--- a/package/components/inline-comment/comment-reply-input.tsx
+++ b/package/components/inline-comment/comment-reply-input.tsx
@@ -18,6 +18,7 @@ export const CommentReplyInput = ({
   commentId,
   replyCount,
   isCollaborationEnabled,
+  commentUsername,
 }: CommentReplyInputProps) => {
   const reply = useCommentStore((s) => s.reply);
   const replyEditTarget = useCommentStore((s) => s.replyEditTarget);
@@ -96,7 +97,7 @@ export const CommentReplyInput = ({
             isCollaborationEnabled
               ? 'Cannot reply in collaboration mode'
               : replyCount === 0
-                ? `Reply to @${nameFormatter(ensStatus.name)}`
+                ? `Reply to @${nameFormatter(commentUsername ?? 'comment')}`
                 : replyCount >= 2
                   ? `Add a reply`
                   : `Reply `

--- a/package/components/inline-comment/comment-section.tsx
+++ b/package/components/inline-comment/comment-section.tsx
@@ -41,6 +41,7 @@ export const CommentSection = ({
   const resolveComment = useCommentStore((s) => s.resolveComment);
   const unresolveComment = useCommentStore((s) => s.unresolveComment);
   const deleteComment = useCommentStore((s) => s.deleteComment);
+  const acceptSuggestion = useCommentStore((s) => s.acceptSuggestion);
   const isConnected = useCommentStore((s) => s.isConnected);
   const connectViaWallet = useCommentStore((s) => s.connectViaWallet);
   const isLoading = useCommentStore((s) => s.isLoading);
@@ -105,6 +106,11 @@ export const CommentSection = ({
             replySectionRef={replySectionRef}
             onCommentClick={handleCommentClick}
             onResolve={(commentId) => {
+              if (comment.isSuggestion) {
+                acceptSuggestion(commentId);
+                return;
+              }
+
               if (isCommentMobileFocused && openReplyId === commentId) {
                 setReOpenLabelCommentId(commentId);
               }
@@ -358,7 +364,7 @@ const SidebarCommentItem = ({
       )}
       onClick={handleSidebarCommentClick}
     >
-      {showReOpenLabel && comment.resolved && (
+      {showReOpenLabel && comment.resolved && !comment.isSuggestion && (
         <div className="w-full px-[16px] py-[8px] rounded-b-[4px] rounded-t-[12px] items-center flex justify-between color-bg-secondary">
           <p className="color-text-secondary text-body-sm">Resolved comment</p>
           <Button
@@ -407,6 +413,7 @@ const SidebarCommentItem = ({
         isResolved={comment.resolved}
         isDisabled={comment && !Object.hasOwn(comment, 'commentIndex')}
         isCommentOwner={comment.username === username || isDDocOwner}
+        canResolveComment={comment.isSuggestion ? isDDocOwner : undefined}
         version={comment.version}
         isSuggestion={comment.isSuggestion}
         suggestionType={comment.suggestionType}

--- a/package/components/inline-comment/comment-section.tsx
+++ b/package/components/inline-comment/comment-section.tsx
@@ -57,7 +57,7 @@ export const CommentSection = ({
   >(null);
 
   const filteredComments = (commentsProp ?? tabComments)
-    .filter((comment) => !comment.deleted)
+    .filter((comment) => !comment.deleted && !comment.isSuggestion)
     .sort(
       (a, b) =>
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),

--- a/package/components/inline-comment/comment-section.tsx
+++ b/package/components/inline-comment/comment-section.tsx
@@ -330,6 +330,7 @@ const SidebarCommentItem = ({
     comment.id,
     comment.selectedContent,
     comment.tabId,
+    Boolean(comment.isSuggestion),
   );
 
   const handleSidebarCommentClick = () => {

--- a/package/components/inline-comment/comment-section.tsx
+++ b/package/components/inline-comment/comment-section.tsx
@@ -57,7 +57,7 @@ export const CommentSection = ({
   >(null);
 
   const filteredComments = (commentsProp ?? tabComments)
-    .filter((comment) => !comment.deleted && !comment.isSuggestion)
+    .filter((comment) => !comment.deleted)
     .sort(
       (a, b) =>
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
@@ -408,8 +408,15 @@ const SidebarCommentItem = ({
         isDisabled={comment && !Object.hasOwn(comment, 'commentIndex')}
         isCommentOwner={comment.username === username || isDDocOwner}
         version={comment.version}
+        isSuggestion={comment.isSuggestion}
+        suggestionType={comment.suggestionType}
+        originalContent={comment.originalContent}
+        suggestedContent={comment.suggestedContent}
         emptyComment={
-          !comment.content && !comment.username && !comment.createdAt
+          !comment.content &&
+          !comment.username &&
+          !comment.createdAt &&
+          !comment.isSuggestion
         }
       />
 

--- a/package/components/inline-comment/comment-section.tsx
+++ b/package/components/inline-comment/comment-section.tsx
@@ -388,9 +388,11 @@ const SidebarCommentItem = ({
               <p className="text-helper-text-sm color-text-secondary">
                 {tabName}
               </p>
-              <p className="text-helper-text-sm flex-1 grow truncate color-text-secondary">
-                {comment.selectedContent}
-              </p>
+              {!comment.isSuggestion && (
+                <p className="text-helper-text-sm flex-1 grow truncate color-text-secondary">
+                  {comment.selectedContent}
+                </p>
+              )}
             </>
           )}
         </>

--- a/package/components/inline-comment/comment-section.tsx
+++ b/package/components/inline-comment/comment-section.tsx
@@ -354,7 +354,7 @@ const SidebarCommentItem = ({
         comment.id === activeCommentId &&
           (isCommentMobileFocused || !isBelow1280px)
           ? 'color-bg-default border'
-          : 'hover:color-bg-default-hover bg-[#00000005] ',
+          : 'hover:color-bg-default-hover color-bg-transparent ',
         comment.replies?.length > 0 && 'gap-0',
         showReOpenLabel && comment.resolved
           ? 'color-bg-default color-border-default'

--- a/package/components/inline-comment/context/types.ts
+++ b/package/components/inline-comment/context/types.ts
@@ -40,6 +40,8 @@ export interface SuggestionFloatingDraftCard extends CommentFloatingBaseCard {
   suggestionId: string;
   /** Accumulated inserted text from the live suggestion context. */
   insertedText: string;
+  /** Pasted link href for link suggestions. */
+  linkHref?: string;
 }
 
 export type CommentFloatingCard =

--- a/package/components/inline-comment/context/types.ts
+++ b/package/components/inline-comment/context/types.ts
@@ -35,9 +35,17 @@ export interface CommentFloatingThreadCard extends CommentFloatingBaseCard {
   commentId: string;
 }
 
+export interface SuggestionFloatingDraftCard extends CommentFloatingBaseCard {
+  type: 'suggestion-draft';
+  suggestionId: string;
+  /** Accumulated inserted text from the live suggestion context. */
+  insertedText: string;
+}
+
 export type CommentFloatingCard =
   | CommentFloatingDraftCard
-  | CommentFloatingThreadCard;
+  | CommentFloatingThreadCard
+  | SuggestionFloatingDraftCard;
 
 export interface InlineCommentData {
   highlightedTextContent?: string;

--- a/package/components/inline-comment/floating-comment-layout-utils.ts
+++ b/package/components/inline-comment/floating-comment-layout-utils.ts
@@ -5,7 +5,7 @@ import {
 } from './comment-floating-layout';
 import type { CommentFloatingCard } from './context/types';
 
-export type AnchorType = 'draft' | 'thread';
+export type AnchorType = 'draft' | 'thread' | 'suggestion-draft';
 
 export interface CachedAnchorRect {
   top: number;
@@ -53,6 +53,13 @@ export const getAnchorIdentity = (floatingCard: CommentFloatingCard) => {
     };
   }
 
+  if (floatingCard.type === 'suggestion-draft') {
+    return {
+      anchorId: floatingCard.suggestionId,
+      anchorType: 'suggestion-draft' as const,
+    };
+  }
+
   return {
     anchorId: floatingCard.commentId,
     anchorType: 'thread' as const,
@@ -74,8 +81,9 @@ const getAnchorSelector = ({
   anchorId: string;
   anchorType: AnchorType;
 }) => {
-  const attribute =
-    anchorType === 'draft' ? 'data-draft-comment-id' : 'data-comment-id';
+  let attribute = 'data-comment-id';
+  if (anchorType === 'draft') attribute = 'data-draft-comment-id';
+  if (anchorType === 'suggestion-draft') attribute = 'data-suggestion-id';
 
   return `[${attribute}="${escapeSelectorValue(anchorId)}"]`;
 };

--- a/package/components/inline-comment/floating-comment-layout-utils.ts
+++ b/package/components/inline-comment/floating-comment-layout-utils.ts
@@ -179,7 +179,7 @@ export const getRect = ({
   elements: HTMLElement[];
   viewportTop: number;
   viewportBottom: number;
-}) => {
+}): { top: number; height: number; intersectsViewport: boolean } | null => {
   const clientRects = elements.flatMap((element) =>
     Array.from(element.getClientRects()),
   );
@@ -188,11 +188,18 @@ export const getRect = ({
     return null;
   }
 
-  const intersectingRect = clientRects.find(
+  const intersectsViewport = clientRects.some(
     (rect) => rect.bottom >= viewportTop && rect.top <= viewportBottom,
   );
 
-  return intersectingRect ?? clientRects[0];
+  const top = Math.min(...clientRects.map((rect) => rect.top));
+  const bottom = Math.max(...clientRects.map((rect) => rect.bottom));
+
+  return {
+    top,
+    height: Math.max(1, bottom - top),
+    intersectsViewport,
+  };
 };
 
 const compareOrderPosition = (aPos: number | null, bPos: number | null) => {

--- a/package/components/inline-comment/floating-comment/comment-floating-container.tsx
+++ b/package/components/inline-comment/floating-comment/comment-floating-container.tsx
@@ -3,6 +3,7 @@ import { useCommentStore } from '../../../stores/comment-store';
 import { useCommentListContainer } from '../use-comment-list-container';
 import { DraftFloatingCard } from './draft-floating-card';
 import { SuggestionDraftFloatingCard } from './suggestion-draft-floating-card';
+import { SuggestionThreadFloatingCard } from './suggestion-thread-floating-card';
 import { ThreadFloatingCard } from './thread-floating-card';
 import type { CommentFloatingContainerProps } from './types';
 import { FLOATING_CARD_WIDTH } from '../constants';
@@ -71,6 +72,21 @@ export const CommentFloatingContainer = ({
         const comment = comments.find(
           (entry) => entry.id === floatingCard.commentId,
         );
+
+        // Suggestions render a distinct thread card — diff summary +
+        // accept/reject/withdraw actions — per the product spec.
+        if (comment?.isSuggestion) {
+          return (
+            <SuggestionThreadFloatingCard
+              key={floatingCard.floatingCardId}
+              thread={floatingCard}
+              comment={comment}
+              tabName={tabName}
+              isHidden={isHidden}
+              registerCardNode={registerCardNode}
+            />
+          );
+        }
 
         return (
           <ThreadFloatingCard

--- a/package/components/inline-comment/floating-comment/comment-floating-container.tsx
+++ b/package/components/inline-comment/floating-comment/comment-floating-container.tsx
@@ -43,7 +43,7 @@ export const CommentFloatingContainer = ({
       data-floating-comment-hidden={isHidden ? 'true' : 'false'}
       style={{
         width: FLOATING_CARD_WIDTH,
-        minHeight: '100%',
+        minHeight: 'var(--floating-comment-container-min-height, 100%)',
       }}
     >
       {mountedFloatingCards.map((floatingCard) => {

--- a/package/components/inline-comment/floating-comment/comment-floating-container.tsx
+++ b/package/components/inline-comment/floating-comment/comment-floating-container.tsx
@@ -2,6 +2,7 @@ import { cn } from '@fileverse/ui';
 import { useCommentStore } from '../../../stores/comment-store';
 import { useCommentListContainer } from '../use-comment-list-container';
 import { DraftFloatingCard } from './draft-floating-card';
+import { SuggestionDraftFloatingCard } from './suggestion-draft-floating-card';
 import { ThreadFloatingCard } from './thread-floating-card';
 import type { CommentFloatingContainerProps } from './types';
 import { FLOATING_CARD_WIDTH } from '../constants';
@@ -50,6 +51,17 @@ export const CommentFloatingContainer = ({
             <DraftFloatingCard
               key={floatingCard.floatingCardId}
               draft={floatingCard}
+              isHidden={isHidden}
+              registerCardNode={registerCardNode}
+            />
+          );
+        }
+
+        if (floatingCard.type === 'suggestion-draft') {
+          return (
+            <SuggestionDraftFloatingCard
+              key={floatingCard.floatingCardId}
+              card={floatingCard}
               isHidden={isHidden}
               registerCardNode={registerCardNode}
             />

--- a/package/components/inline-comment/floating-comment/comment-floating-container.tsx
+++ b/package/components/inline-comment/floating-comment/comment-floating-container.tsx
@@ -84,6 +84,7 @@ export const CommentFloatingContainer = ({
               tabName={tabName}
               isHidden={isHidden}
               registerCardNode={registerCardNode}
+              isCollaborationEnabled={isCollaborationEnabled}
             />
           );
         }

--- a/package/components/inline-comment/floating-comment/comment-floating-container.tsx
+++ b/package/components/inline-comment/floating-comment/comment-floating-container.tsx
@@ -7,6 +7,7 @@ import { SuggestionThreadFloatingCard } from './suggestion-thread-floating-card'
 import { ThreadFloatingCard } from './thread-floating-card';
 import type { CommentFloatingContainerProps } from './types';
 import { FLOATING_CARD_WIDTH } from '../constants';
+import { FLOATING_COMMENT_RIGHT_SPACE } from '../comment-floating-layout';
 
 export const CommentFloatingContainer = ({
   editor,
@@ -43,7 +44,9 @@ export const CommentFloatingContainer = ({
       data-floating-comment-hidden={isHidden ? 'true' : 'false'}
       style={{
         width: FLOATING_CARD_WIDTH,
+        boxSizing: 'content-box',
         minHeight: 'var(--floating-comment-container-min-height, 100%)',
+        paddingRight: isHidden ? 0 : FLOATING_COMMENT_RIGHT_SPACE,
       }}
     >
       {mountedFloatingCards.map((floatingCard) => {

--- a/package/components/inline-comment/floating-comment/draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/draft-floating-card.tsx
@@ -1,5 +1,5 @@
 import { Avatar, Button, TextAreaFieldV2 } from '@fileverse/ui';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useCommentStore } from '../../../stores/comment-store';
 import { resizeInlineCommentTextarea } from '../resize-inline-comment-textarea';
 import { FloatingAuthPrompt } from './floating-auth-prompt';
@@ -22,6 +22,13 @@ export const DraftFloatingCard = ({
   const isConnected = useCommentStore((s) => s.isConnected);
   const draftCardRef = useRef<HTMLDivElement | null>(null);
   const ensStatus = useEnsStatus(username);
+  const handleCardNode = useCallback(
+    (node: HTMLDivElement | null) => {
+      draftCardRef.current = node;
+      registerCardNode(draft.floatingCardId, node);
+    },
+    [draft.floatingCardId, registerCardNode],
+  );
 
   useEffect(() => {
     if (!draftState || !draft.isFocused || isHidden) {
@@ -47,10 +54,7 @@ export const DraftFloatingCard = ({
 
   return (
     <FloatingCardShell
-      ref={(node) => {
-        draftCardRef.current = node;
-        registerCardNode(draft.floatingCardId, node);
-      }}
+      ref={handleCardNode}
       floatingCardId={draft.floatingCardId}
       isHidden={isHidden}
       isFocused={draft.isFocused}

--- a/package/components/inline-comment/floating-comment/floating-card-shell.tsx
+++ b/package/components/inline-comment/floating-comment/floating-card-shell.tsx
@@ -24,7 +24,7 @@ export const FloatingCardShell = forwardRef<
       ref={ref}
       data-floating-comment-card={floatingCardId}
       className={cn(
-        'absolute left-0 top-0 pb-[12px] border cursor-pointer rounded-[12px] will-change-transform transition-[box-shadow,border-color] duration-150 ease-out',
+        'absolute left-0 top-0 pb-[12px] select-text border cursor-pointer rounded-[12px] will-change-transform transition-[box-shadow,border-color] duration-150 ease-out',
         isFocused
           ? 'shadow-elevation-3 color-bg-default color-border-default'
           : 'color-bg-transparent border-transparent hover:color-bg-default-hover hover:color-border-default',

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@fileverse/ui';
+import { Button, IconButton } from '@fileverse/ui';
 import { useCommentStore } from '../../../stores/comment-store';
 import { FloatingCardShell } from './floating-card-shell';
 import type { SuggestionDraftFloatingCardProps } from './types';
@@ -7,9 +7,9 @@ import type { SuggestionDraftFloatingCardProps } from './types';
  * SuggestionDraftFloatingCard
  *
  * Shown while a viewer is composing a suggestion (in suggestion mode).
- * Displays the original text (strikethrough) and the inserted text (green),
- * matching the inline decorations already visible in the editor.
- * Submit finalizes the suggestion; Discard undoes the edits.
+ * Uses the same one-line diff format as the submitted thread card
+ * (Add: "X" / Delete: "X" / Replace: "X" with "Y") plus a Submit action
+ * and a Discard (X) button.
  */
 export const SuggestionDraftFloatingCard = ({
   card,
@@ -24,6 +24,14 @@ export const SuggestionDraftFloatingCard = ({
   const hasInserted = Boolean(card.insertedText);
   const canSubmit = hasOriginal || hasInserted;
 
+  const suggestionType: 'add' | 'delete' | 'replace' | null = hasOriginal
+    ? hasInserted
+      ? 'replace'
+      : 'delete'
+    : hasInserted
+      ? 'add'
+      : null;
+
   return (
     <FloatingCardShell
       ref={(node) => registerCardNode(card.floatingCardId, node)}
@@ -33,38 +41,53 @@ export const SuggestionDraftFloatingCard = ({
       onFocus={() => focusFloatingCard(card.floatingCardId)}
     >
       <div className="flex flex-col gap-2 p-3">
-        <p className="text-body-xs-bold color-text-secondary uppercase tracking-wide">
-          Suggestion
-        </p>
-
-        {/* Content preview — mirrors what the inline decorations show */}
-        <div className="rounded-[4px] border color-border-default px-3 py-2 text-body-sm space-y-1">
-          {hasOriginal && (
-            <span className="line-through color-text-secondary">
-              {card.selectedText}
-            </span>
-          )}
-          {hasOriginal && hasInserted && <span> → </span>}
-          {hasInserted && (
-            <span className="text-[#22c55e]">{card.insertedText}</span>
-          )}
-          {!hasOriginal && !hasInserted && (
-            <span className="color-text-secondary italic">No changes yet</span>
-          )}
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            {suggestionType === 'add' && (
+              <p className="text-body-sm">
+                <span className="font-semibold">Add:</span>{' '}
+                <span>&ldquo;{card.insertedText}&rdquo;</span>
+              </p>
+            )}
+            {suggestionType === 'delete' && (
+              <p className="text-body-sm">
+                <span className="font-semibold">Delete:</span>{' '}
+                <span className="line-through">
+                  &ldquo;{card.selectedText}&rdquo;
+                </span>
+              </p>
+            )}
+            {suggestionType === 'replace' && (
+              <p className="text-body-sm">
+                <span className="font-semibold">Replace:</span>{' '}
+                <span className="line-through">
+                  &ldquo;{card.selectedText}&rdquo;
+                </span>{' '}
+                <span className="font-semibold">with</span>{' '}
+                <span>&ldquo;{card.insertedText}&rdquo;</span>
+              </p>
+            )}
+            {!suggestionType && (
+              <p className="text-body-sm color-text-secondary italic">
+                Start typing to suggest a change
+              </p>
+            )}
+          </div>
+          <IconButton
+            icon="X"
+            variant="ghost"
+            size="sm"
+            onClick={() => discardDraft(card.suggestionId)}
+            title="Discard suggestion"
+          />
         </div>
 
-        <div className="flex items-center justify-end gap-2">
+        <div className="flex items-center justify-end">
           <Button
-            variant="ghost"
-            className="!w-[80px] !min-w-[80px]"
-            onClick={() => discardDraft(card.suggestionId)}
-          >
-            Discard
-          </Button>
-          <Button
-            className="w-20 min-w-20"
+            size="sm"
             disabled={!canSubmit}
             onClick={() => submitDraft(card.suggestionId)}
+            className="!min-w-[80px]"
           >
             Submit
           </Button>

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -5,6 +5,7 @@ import { FloatingCardShell } from './floating-card-shell';
 import { FloatingAuthPrompt } from './floating-auth-prompt';
 import type { SuggestionDraftFloatingCardProps } from './types';
 import { useEnsStatus } from '../use-ens-status';
+import { SuggestionDiffSummary } from '../suggestion-diff-summary';
 import EnsLogo from '../../../assets/ens.svg';
 import { dateFormatter, nameFormatter } from '../../../utils/helpers';
 import verifiedMark from '../../../assets/ens-check.svg';
@@ -108,41 +109,12 @@ export const SuggestionDraftFloatingCard = ({
           </div>
 
           <div className="flex-1 ml-[32px]">
-            {suggestionType === 'add' && (
-              <p className="text-body-sm break-words">
-                <span className="font-semibold">Add:</span>{' '}
-                <span>&ldquo;{card.insertedText}&rdquo;</span>
-              </p>
-            )}
-            {suggestionType === 'delete' && (
-              <p className="text-body-sm">
-                <span className="font-semibold">Delete:</span>{' '}
-                <span className="line-through">
-                  &ldquo;{card.selectedText}&rdquo;
-                </span>
-              </p>
-            )}
-            {suggestionType === 'replace' && (
-              <p className="text-body-sm">
-                <span className="font-semibold">Replace:</span>{' '}
-                <span className="line-through">
-                  &ldquo;{card.selectedText}&rdquo;
-                </span>{' '}
-                <span className="font-semibold">with</span>{' '}
-                <span>&ldquo;{card.insertedText}&rdquo;</span>
-              </p>
-            )}
-            {suggestionType === 'link' && (
-              <p className="text-body-sm break-words">
-                <span className="font-semibold">Add link:</span>{' '}
-                <span>&quot;{card.linkHref}&quot;</span>
-              </p>
-            )}
-            {!suggestionType && (
-              <p className="text-body-sm color-text-secondary italic">
-                Start typing to suggest a change
-              </p>
-            )}
+            <SuggestionDiffSummary
+              suggestionType={suggestionType}
+              originalContent={card.selectedText}
+              suggestedContent={card.linkHref ?? card.insertedText}
+              emptyText="Start typing to suggest a change"
+            />
           </div>
 
           <div className="flex items-center justify-end">

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -1,4 +1,5 @@
 import { Avatar, Button, IconButton } from '@fileverse/ui';
+import { useCallback } from 'react';
 import { useCommentStore } from '../../../stores/comment-store';
 import { FloatingCardShell } from './floating-card-shell';
 import { FloatingAuthPrompt } from './floating-auth-prompt';
@@ -38,6 +39,12 @@ export const SuggestionDraftFloatingCard = ({
   const canSubmit = hasOriginal || hasInserted || hasLink;
   const username = useCommentStore((s) => s.username);
   const ensStatus = useEnsStatus(username);
+  const handleCardNode = useCallback(
+    (node: HTMLDivElement | null) => {
+      registerCardNode(card.floatingCardId, node);
+    },
+    [card.floatingCardId, registerCardNode],
+  );
 
   const suggestionType: 'add' | 'delete' | 'replace' | 'link' | null = hasLink
     ? 'link'
@@ -51,7 +58,7 @@ export const SuggestionDraftFloatingCard = ({
 
   return (
     <FloatingCardShell
-      ref={(node) => registerCardNode(card.floatingCardId, node)}
+      ref={handleCardNode}
       floatingCardId={card.floatingCardId}
       isHidden={isHidden}
       isFocused={card.isFocused}

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -133,7 +133,7 @@ export const SuggestionDraftFloatingCard = ({
               </p>
             )}
             {suggestionType === 'link' && (
-              <p className="text-body-sm">
+              <p className="text-body-sm break-words">
                 <span className="font-semibold">Add link:</span>{' '}
                 <span>&quot;{card.linkHref}&quot;</span>
               </p>

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -34,17 +34,20 @@ export const SuggestionDraftFloatingCard = ({
 
   const hasOriginal = Boolean(card.selectedText);
   const hasInserted = Boolean(card.insertedText);
-  const canSubmit = hasOriginal || hasInserted;
+  const hasLink = Boolean(card.linkHref);
+  const canSubmit = hasOriginal || hasInserted || hasLink;
   const username = useCommentStore((s) => s.username);
   const ensStatus = useEnsStatus(username);
 
-  const suggestionType: 'add' | 'delete' | 'replace' | null = hasOriginal
-    ? hasInserted
-      ? 'replace'
-      : 'delete'
-    : hasInserted
-      ? 'add'
-      : null;
+  const suggestionType: 'add' | 'delete' | 'replace' | 'link' | null = hasLink
+    ? 'link'
+    : hasOriginal
+      ? hasInserted
+        ? 'replace'
+        : 'delete'
+      : hasInserted
+        ? 'add'
+        : null;
 
   return (
     <FloatingCardShell
@@ -96,7 +99,7 @@ export const SuggestionDraftFloatingCard = ({
 
           <div className="flex-1 ml-[32px]">
             {suggestionType === 'add' && (
-              <p className="text-body-sm">
+              <p className="text-body-sm break-words">
                 <span className="font-semibold">Add:</span>{' '}
                 <span>&ldquo;{card.insertedText}&rdquo;</span>
               </p>
@@ -117,6 +120,12 @@ export const SuggestionDraftFloatingCard = ({
                 </span>{' '}
                 <span className="font-semibold">with</span>{' '}
                 <span>&ldquo;{card.insertedText}&rdquo;</span>
+              </p>
+            )}
+            {suggestionType === 'link' && (
+              <p className="text-body-sm">
+                <span className="font-semibold">Add link:</span>{' '}
+                <span>&quot;{card.linkHref}&quot;</span>
               </p>
             )}
             {!suggestionType && (

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -1,8 +1,12 @@
-import { Button, IconButton } from '@fileverse/ui';
+import { Avatar, Button, IconButton } from '@fileverse/ui';
 import { useCommentStore } from '../../../stores/comment-store';
 import { FloatingCardShell } from './floating-card-shell';
 import { FloatingAuthPrompt } from './floating-auth-prompt';
 import type { SuggestionDraftFloatingCardProps } from './types';
+import { useEnsStatus } from '../use-ens-status';
+import EnsLogo from '../../../assets/ens.svg';
+import { dateFormatter, nameFormatter } from '../../../utils/helpers';
+import verifiedMark from '../../../assets/ens-check.svg';
 
 /**
  * SuggestionDraftFloatingCard
@@ -31,6 +35,8 @@ export const SuggestionDraftFloatingCard = ({
   const hasOriginal = Boolean(card.selectedText);
   const hasInserted = Boolean(card.insertedText);
   const canSubmit = hasOriginal || hasInserted;
+  const username = useCommentStore((s) => s.username);
+  const ensStatus = useEnsStatus(username);
 
   const suggestionType: 'add' | 'delete' | 'replace' | null = hasOriginal
     ? hasInserted
@@ -51,9 +57,44 @@ export const SuggestionDraftFloatingCard = ({
       {!isConnected ? (
         <FloatingAuthPrompt />
       ) : (
-        <div className="flex flex-col gap-2 p-3">
-        <div className="flex items-start gap-2">
-          <div className="flex-1">
+        <div className="flex flex-col gap-2 p-3 pb-0">
+          <div className="flex items-center gap-2">
+            <Avatar
+              src={
+                ensStatus.isEns
+                  ? EnsLogo
+                  : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
+                      ensStatus.name,
+                    )}`
+              }
+              size="sm"
+              className="min-w-6"
+            />
+            <span className="text-body-sm-bold inline-flex items-center gap-1 whitespace-nowrap">
+              {nameFormatter(ensStatus.name)}
+              {ensStatus.isEns && (
+                <img
+                  src={verifiedMark}
+                  alt="verified"
+                  className="w-3.5 h-3.5"
+                />
+              )}
+            </span>
+            <span className="text-helper-text-sm color-text-secondary whitespace-nowrap">
+              {dateFormatter(Date.now())}
+            </span>
+            <div className="ml-auto flex items-center gap-1">
+              <IconButton
+                icon="X"
+                variant="ghost"
+                size="sm"
+                onClick={() => discardDraft(card.suggestionId)}
+                title="Discard suggestion"
+              />
+            </div>
+          </div>
+
+          <div className="flex-1 ml-[32px]">
             {suggestionType === 'add' && (
               <p className="text-body-sm">
                 <span className="font-semibold">Add:</span>{' '}
@@ -84,25 +125,17 @@ export const SuggestionDraftFloatingCard = ({
               </p>
             )}
           </div>
-          <IconButton
-            icon="X"
-            variant="ghost"
-            size="sm"
-            onClick={() => discardDraft(card.suggestionId)}
-            title="Discard suggestion"
-          />
-        </div>
 
-        <div className="flex items-center justify-end">
-          <Button
-            size="sm"
-            disabled={!canSubmit}
-            onClick={() => submitDraft(card.suggestionId)}
-            className="!min-w-[80px]"
-          >
-            Submit
-          </Button>
-        </div>
+          <div className="flex items-center justify-end">
+            <Button
+              size="sm"
+              disabled={!canSubmit}
+              onClick={() => submitDraft(card.suggestionId)}
+              className="!min-w-[80px]"
+            >
+              Submit
+            </Button>
+          </div>
         </div>
       )}
     </FloatingCardShell>

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -58,7 +58,7 @@ export const SuggestionDraftFloatingCard = ({
       onFocus={() => focusFloatingCard(card.floatingCardId)}
     >
       {!isConnected ? (
-        <FloatingAuthPrompt />
+        <FloatingAuthPrompt isDraft={true} />
       ) : (
         <div className="flex flex-col gap-2 p-3 pb-0">
           <div className="flex items-center gap-2">
@@ -74,7 +74,10 @@ export const SuggestionDraftFloatingCard = ({
               className="min-w-6"
             />
             <span className="text-body-sm-bold inline-flex items-center gap-1 whitespace-nowrap">
-              {nameFormatter(ensStatus.name)}
+              <p className="truncate max-w-[230px]">
+                {nameFormatter(ensStatus.name)}
+              </p>
+
               {ensStatus.isEns && (
                 <img
                   src={verifiedMark}

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -1,6 +1,7 @@
 import { Button, IconButton } from '@fileverse/ui';
 import { useCommentStore } from '../../../stores/comment-store';
 import { FloatingCardShell } from './floating-card-shell';
+import { FloatingAuthPrompt } from './floating-auth-prompt';
 import type { SuggestionDraftFloatingCardProps } from './types';
 
 /**
@@ -10,6 +11,12 @@ import type { SuggestionDraftFloatingCardProps } from './types';
  * Uses the same one-line diff format as the submitted thread card
  * (Add: "X" / Delete: "X" / Replace: "X" with "Y") plus a Submit action
  * and a Discard (X) button.
+ *
+ * When the viewer hasn't joined yet (no username / wallet), the card
+ * renders FloatingAuthPrompt inside — same pattern as the inline-comment
+ * draft card. The first keystroke that triggered this card is preserved
+ * as the draft's first character; once the viewer joins, the card
+ * transitions to the normal diff/Submit UI without losing what they typed.
  */
 export const SuggestionDraftFloatingCard = ({
   card,
@@ -19,6 +26,7 @@ export const SuggestionDraftFloatingCard = ({
   const focusFloatingCard = useCommentStore((s) => s.focusFloatingCard);
   const submitDraft = useCommentStore((s) => s.submitDraft);
   const discardDraft = useCommentStore((s) => s.discardDraft);
+  const isConnected = useCommentStore((s) => s.isConnected);
 
   const hasOriginal = Boolean(card.selectedText);
   const hasInserted = Boolean(card.insertedText);
@@ -40,7 +48,10 @@ export const SuggestionDraftFloatingCard = ({
       isFocused={card.isFocused}
       onFocus={() => focusFloatingCard(card.floatingCardId)}
     >
-      <div className="flex flex-col gap-2 p-3">
+      {!isConnected ? (
+        <FloatingAuthPrompt />
+      ) : (
+        <div className="flex flex-col gap-2 p-3">
         <div className="flex items-start gap-2">
           <div className="flex-1">
             {suggestionType === 'add' && (
@@ -92,7 +103,8 @@ export const SuggestionDraftFloatingCard = ({
             Submit
           </Button>
         </div>
-      </div>
+        </div>
+      )}
     </FloatingCardShell>
   );
 };

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -17,10 +17,8 @@ export const SuggestionDraftFloatingCard = ({
   registerCardNode,
 }: SuggestionDraftFloatingCardProps) => {
   const focusFloatingCard = useCommentStore((s) => s.focusFloatingCard);
-  // TODO(phase-4): wire Submit → store.submitDraft, Discard → store.discardDraft
-  // once the new draft-model store actions land.
-  const submitSuggestionDraft = (_id: string) => {};
-  const discardSuggestionDraft = (_id: string) => {};
+  const submitDraft = useCommentStore((s) => s.submitDraft);
+  const discardDraft = useCommentStore((s) => s.discardDraft);
 
   const hasOriginal = Boolean(card.selectedText);
   const hasInserted = Boolean(card.insertedText);
@@ -59,14 +57,14 @@ export const SuggestionDraftFloatingCard = ({
           <Button
             variant="ghost"
             className="!w-[80px] !min-w-[80px]"
-            onClick={() => discardSuggestionDraft(card.suggestionId)}
+            onClick={() => discardDraft(card.suggestionId)}
           >
             Discard
           </Button>
           <Button
             className="w-20 min-w-20"
             disabled={!canSubmit}
-            onClick={() => submitSuggestionDraft(card.suggestionId)}
+            onClick={() => submitDraft(card.suggestionId)}
           >
             Submit
           </Button>

--- a/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-draft-floating-card.tsx
@@ -1,0 +1,77 @@
+import { Button } from '@fileverse/ui';
+import { useCommentStore } from '../../../stores/comment-store';
+import { FloatingCardShell } from './floating-card-shell';
+import type { SuggestionDraftFloatingCardProps } from './types';
+
+/**
+ * SuggestionDraftFloatingCard
+ *
+ * Shown while a viewer is composing a suggestion (in suggestion mode).
+ * Displays the original text (strikethrough) and the inserted text (green),
+ * matching the inline decorations already visible in the editor.
+ * Submit finalizes the suggestion; Discard undoes the edits.
+ */
+export const SuggestionDraftFloatingCard = ({
+  card,
+  isHidden,
+  registerCardNode,
+}: SuggestionDraftFloatingCardProps) => {
+  const focusFloatingCard = useCommentStore((s) => s.focusFloatingCard);
+  // TODO(phase-4): wire Submit → store.submitDraft, Discard → store.discardDraft
+  // once the new draft-model store actions land.
+  const submitSuggestionDraft = (_id: string) => {};
+  const discardSuggestionDraft = (_id: string) => {};
+
+  const hasOriginal = Boolean(card.selectedText);
+  const hasInserted = Boolean(card.insertedText);
+  const canSubmit = hasOriginal || hasInserted;
+
+  return (
+    <FloatingCardShell
+      ref={(node) => registerCardNode(card.floatingCardId, node)}
+      floatingCardId={card.floatingCardId}
+      isHidden={isHidden}
+      isFocused={card.isFocused}
+      onFocus={() => focusFloatingCard(card.floatingCardId)}
+    >
+      <div className="flex flex-col gap-2 p-3">
+        <p className="text-body-xs-bold color-text-secondary uppercase tracking-wide">
+          Suggestion
+        </p>
+
+        {/* Content preview — mirrors what the inline decorations show */}
+        <div className="rounded-[4px] border color-border-default px-3 py-2 text-body-sm space-y-1">
+          {hasOriginal && (
+            <span className="line-through color-text-secondary">
+              {card.selectedText}
+            </span>
+          )}
+          {hasOriginal && hasInserted && <span> → </span>}
+          {hasInserted && (
+            <span className="text-[#22c55e]">{card.insertedText}</span>
+          )}
+          {!hasOriginal && !hasInserted && (
+            <span className="color-text-secondary italic">No changes yet</span>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end gap-2">
+          <Button
+            variant="ghost"
+            className="!w-[80px] !min-w-[80px]"
+            onClick={() => discardSuggestionDraft(card.suggestionId)}
+          >
+            Discard
+          </Button>
+          <Button
+            className="w-20 min-w-20"
+            disabled={!canSubmit}
+            onClick={() => submitSuggestionDraft(card.suggestionId)}
+          >
+            Submit
+          </Button>
+        </div>
+      </div>
+    </FloatingCardShell>
+  );
+};

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -31,7 +31,6 @@ export const SuggestionThreadFloatingCard = ({
   const focusCommentInEditor = useCommentStore((s) => s.focusCommentInEditor);
   const isDDocOwner = useCommentStore((s) => s.isDDocOwner);
   const currentUsername = useCommentStore((s) => s.username);
-  const mySubmittedIds = useCommentStore((s) => s.mySubmittedSuggestionIds);
   const acceptSuggestion = useCommentStore((s) => s.acceptSuggestion);
   const deleteComment = useCommentStore((s) => s.deleteComment);
 
@@ -44,12 +43,12 @@ export const SuggestionThreadFloatingCard = ({
     }
   };
 
-  // Authored by this viewer if either the stored username matches or the
-  // session-local "submitted by me" set has the id (covers viewers without
-  // a persistent username).
-  const isAuthor =
-    Boolean(comment.username && comment.username === currentUsername) ||
-    (comment.id ? mySubmittedIds.has(comment.id) : false);
+  // Same author check used by regular comments (comment-card.tsx). Consumer
+  // persists the username (incl. random-account names from FloatingAuthPrompt)
+  // in localStorage and restores it on reload, so this carries across reloads.
+  const isAuthor = Boolean(
+    currentUsername && comment.username && comment.username === currentUsername,
+  );
   const canAcceptReject = isDDocOwner;
   const canWithdraw = !isDDocOwner && isAuthor;
 

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -8,6 +8,7 @@ import { CommentRepliesThread } from '../comment-card';
 import { useCommentCard } from '../use-comment-card';
 import { useEnsStatus } from '../use-ens-status';
 import { resizeInlineCommentTextarea } from '../resize-inline-comment-textarea';
+import { SuggestionDiffSummary } from '../suggestion-diff-summary';
 import { FloatingAuthPrompt } from './floating-auth-prompt';
 import { FloatingCardShell } from './floating-card-shell';
 import type { ThreadFloatingCardProps } from './types';
@@ -91,7 +92,11 @@ export const SuggestionThreadFloatingCard = ({
           onReject={handleReject}
         />
         <div className="ml-[32px]">
-          <DiffSummary comment={comment} />
+          <SuggestionDiffSummary
+            suggestionType={comment.suggestionType}
+            originalContent={comment.originalContent}
+            suggestedContent={comment.suggestedContent}
+          />
         </div>
 
         <RepliesThread
@@ -186,65 +191,6 @@ const Header = ({
       </div>
     </div>
   );
-};
-
-// ---------------------------------------------------------------------------
-// DiffSummary — one-line suggestion description
-//   Add:     Add: "lorem"
-//   Delete:  Delete: "concepts"
-//   Replace: Replace: "concepts" with "lorem"
-// ---------------------------------------------------------------------------
-
-const DiffSummary = ({
-  comment,
-}: {
-  comment: NonNullable<ThreadFloatingCardProps['comment']>;
-}) => {
-  const {
-    suggestionType,
-    originalContent = '',
-    suggestedContent = '',
-  } = comment;
-
-  if (suggestionType === 'add') {
-    return (
-      <p className="text-body-sm break-words">
-        <span className="font-semibold">Add:</span>{' '}
-        <span>&ldquo;{suggestedContent}&rdquo;</span>
-      </p>
-    );
-  }
-
-  if (suggestionType === 'delete') {
-    return (
-      <p className="text-body-sm break-words">
-        <span className="font-semibold">Delete:</span>{' '}
-        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>
-      </p>
-    );
-  }
-
-  if (suggestionType === 'replace') {
-    return (
-      <p className="text-body-sm break-words">
-        <span className="font-semibold">Replace:</span>{' '}
-        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>{' '}
-        <span className="font-semibold">with</span>{' '}
-        <span>&ldquo;{suggestedContent}&rdquo;</span>
-      </p>
-    );
-  }
-
-  if (suggestionType === 'link') {
-    return (
-      <p className="text-body-sm break-words">
-        <span className="font-semibold">Add link:</span>{' '}
-        <span>&quot;{suggestedContent}&quot;</span>
-      </p>
-    );
-  }
-
-  return null;
 };
 
 // ---------------------------------------------------------------------------

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -136,7 +136,9 @@ const Header = ({
         className="min-w-6"
       />
       <span className="text-body-sm-bold inline-flex items-center gap-1 whitespace-nowrap">
-        {nameFormatter(ensStatus.name)}
+        <p className="truncate max-w-[230px]">
+          {nameFormatter(ensStatus.name)}
+        </p>
         {ensStatus.isEns && (
           <img src={verifiedMark} alt="verified" className="w-3.5 h-3.5" />
         )}

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -29,6 +29,7 @@ export const SuggestionThreadFloatingCard = ({
   comment,
   isHidden,
   registerCardNode,
+  isCollaborationEnabled,
 }: ThreadFloatingCardProps) => {
   const focusFloatingCard = useCommentStore((s) => s.focusFloatingCard);
   const focusCommentInEditor = useCommentStore((s) => s.focusCommentInEditor);
@@ -99,7 +100,11 @@ export const SuggestionThreadFloatingCard = ({
           onFocusRequest={handleFocus}
         />
 
-        <ReplyField thread={thread} comment={comment} />
+        <ReplyField
+          thread={thread}
+          comment={comment}
+          isCollaborationEnabled={isCollaborationEnabled}
+        />
       </div>
     </FloatingCardShell>
   );
@@ -142,9 +147,7 @@ const Header = ({
         className="min-w-6"
       />
       <span className="text-body-sm-bold inline-flex items-center gap-1 whitespace-nowrap">
-        <p className="truncate max-w-[230px]">
-          {nameFormatter(ensStatus.name)}
-        </p>
+        <p className="truncate max-w-[86px]">{nameFormatter(ensStatus.name)}</p>
         {ensStatus.isEns && (
           <img src={verifiedMark} alt="verified" className="w-3.5 h-3.5" />
         )}
@@ -310,9 +313,11 @@ const RepliesThread = ({
 const ReplyField = ({
   thread,
   comment,
+  isCollaborationEnabled,
 }: {
   thread: ThreadFloatingCardProps['thread'];
   comment: NonNullable<ThreadFloatingCardProps['comment']>;
+  isCollaborationEnabled?: boolean;
 }) => {
   const username = useCommentStore((s) => s.username);
   const isConnected = useCommentStore((s) => s.isConnected);
@@ -323,8 +328,9 @@ const ReplyField = ({
   const replyTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const canReply = !comment.resolved && !comment.deleted;
   const hasUnsentReply = Boolean(replyText.trim());
-  const shouldShowReplyField =
-    isConnected && (thread.isFocused || hasUnsentReply);
+  const shouldShowReplyField = isCollaborationEnabled
+    ? thread.isFocused
+    : isConnected && (thread.isFocused || hasUnsentReply);
   const ensStatus = useEnsStatus(username);
 
   useEffect(() => {
@@ -334,6 +340,7 @@ const ReplyField = ({
   }, [replyText]);
 
   const handleSubmit = () => {
+    if (isCollaborationEnabled) return;
     if (!thread.commentId || !replyText.trim()) return;
     if (!isConnected) {
       setCommentDrawerOpen?.(true);
@@ -346,7 +353,7 @@ const ReplyField = ({
 
   if (!canReply) return null;
 
-  if (thread.isFocused && !isConnected) {
+  if (thread.isFocused && !isConnected && !isCollaborationEnabled) {
     return <FloatingAuthPrompt />;
   }
 
@@ -354,7 +361,12 @@ const ReplyField = ({
 
   return (
     <div className="group">
-      <div className="border flex px-[12px] py-[8px] gap-[8px] rounded-[4px] color-bg-default">
+      <div
+        className={cn(
+          'border flex px-[12px] py-[8px] gap-[8px] rounded-[4px]',
+          isCollaborationEnabled ? 'color-bg-disabled' : 'color-bg-default',
+        )}
+      >
         <Avatar
           src={
             ensStatus.isEns
@@ -382,8 +394,14 @@ const ReplyField = ({
             }
           }}
           className="color-bg-default w-full text-body-sm color-text-default !p-0 !border-none h-[20px] max-h-[296px] overflow-y-auto no-scrollbar whitespace-pre-wrap"
-          placeholder={canReply ? 'Add a reply' : 'Thread resolved'}
-          disabled={!canReply}
+          placeholder={
+            isCollaborationEnabled
+              ? 'Cannot send reply in collaboration mode'
+              : canReply
+                ? 'Add a reply'
+                : 'Thread resolved'
+          }
+          disabled={!canReply || isCollaborationEnabled}
         />
       </div>
       <div
@@ -405,7 +423,7 @@ const ReplyField = ({
         </Button>
         <Button
           className="w-20 min-w-20"
-          disabled={!replyText.trim()}
+          disabled={!replyText.trim() || isCollaborationEnabled}
           onClick={handleSubmit}
         >
           Send

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -1,0 +1,356 @@
+import { Avatar, Button, IconButton, TextAreaFieldV2, cn } from '@fileverse/ui';
+import { useEffect, useRef, useState } from 'react';
+import { useCommentStore } from '../../../stores/comment-store';
+import EnsLogo from '../../../assets/ens.svg';
+import verifiedMark from '../../../assets/ens-check.svg';
+import { dateFormatter, nameFormatter } from '../../../utils/helpers';
+import { useEnsStatus } from '../use-ens-status';
+import { resizeInlineCommentTextarea } from '../resize-inline-comment-textarea';
+import { FloatingCardShell } from './floating-card-shell';
+import type { ThreadFloatingCardProps } from './types';
+
+/**
+ * SuggestionThreadFloatingCard
+ *
+ * Shown in place of the generic ThreadFloatingCard for submitted suggestions
+ * (comments with `isSuggestion: true`). Renders the Figma-specified layout:
+ * author + timestamp header, Accept/Reject (owner) or Withdraw (author)
+ * actions, a one-line diff summary (Add/Delete/Replace), and a reply input.
+ *
+ * Renders from the underlying IComment — the same source ThreadFloatingCard
+ * uses — so once a draft is submitted, nothing else in the pipeline needs
+ * to change to show the suggestion here.
+ */
+export const SuggestionThreadFloatingCard = ({
+  thread,
+  comment,
+  isHidden,
+  registerCardNode,
+}: ThreadFloatingCardProps) => {
+  const focusFloatingCard = useCommentStore((s) => s.focusFloatingCard);
+  const focusCommentInEditor = useCommentStore((s) => s.focusCommentInEditor);
+  const isDDocOwner = useCommentStore((s) => s.isDDocOwner);
+  const currentUsername = useCommentStore((s) => s.username);
+  const mySubmittedIds = useCommentStore((s) => s.mySubmittedSuggestionIds);
+  const acceptSuggestion = useCommentStore((s) => s.acceptSuggestion);
+  const deleteComment = useCommentStore((s) => s.deleteComment);
+
+  if (!comment) return null;
+
+  const handleFocus = () => {
+    focusFloatingCard(thread.floatingCardId);
+    if (!thread.isFocused && thread.commentId) {
+      focusCommentInEditor(thread.commentId);
+    }
+  };
+
+  // Authored by this viewer if either the stored username matches or the
+  // session-local "submitted by me" set has the id (covers viewers without
+  // a persistent username).
+  const isAuthor =
+    Boolean(comment.username && comment.username === currentUsername) ||
+    (comment.id ? mySubmittedIds.has(comment.id) : false);
+  const canAcceptReject = isDDocOwner;
+  const canWithdraw = !isDDocOwner && isAuthor;
+
+  const handleAccept = () => {
+    if (!thread.commentId) return;
+    acceptSuggestion(thread.commentId);
+  };
+
+  const handleReject = () => {
+    if (!thread.commentId) return;
+    deleteComment(thread.commentId);
+  };
+
+  return (
+    <FloatingCardShell
+      ref={(node) => registerCardNode(thread.floatingCardId, node)}
+      floatingCardId={thread.floatingCardId}
+      isHidden={isHidden}
+      isFocused={thread.isFocused}
+      onFocus={handleFocus}
+    >
+      <div className="flex flex-col gap-2 p-3">
+        <Header
+          username={comment.username}
+          createdAt={comment.createdAt}
+          canAcceptReject={canAcceptReject}
+          canWithdraw={canWithdraw}
+          onAccept={handleAccept}
+          onReject={handleReject}
+        />
+
+        <DiffSummary comment={comment} />
+
+        <RepliesList comment={comment} />
+
+        <ReplyField thread={thread} comment={comment} />
+      </div>
+    </FloatingCardShell>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Header — avatar + username + timestamp + Accept/Reject/Withdraw icons
+// ---------------------------------------------------------------------------
+
+interface HeaderProps {
+  username: string | undefined;
+  createdAt: Date | undefined;
+  canAcceptReject: boolean;
+  canWithdraw: boolean;
+  onAccept: () => void;
+  onReject: () => void;
+}
+
+const Header = ({
+  username,
+  createdAt,
+  canAcceptReject,
+  canWithdraw,
+  onAccept,
+  onReject,
+}: HeaderProps) => {
+  const ensStatus = useEnsStatus(username);
+
+  return (
+    <div className="flex items-center gap-2">
+      <Avatar
+        src={
+          ensStatus.isEns
+            ? EnsLogo
+            : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
+                ensStatus.name,
+              )}`
+        }
+        size="sm"
+        className="min-w-6"
+      />
+      <span className="text-body-sm-bold inline-flex items-center gap-1 whitespace-nowrap">
+        {nameFormatter(ensStatus.name)}
+        {ensStatus.isEns && (
+          <img src={verifiedMark} alt="verified" className="w-3.5 h-3.5" />
+        )}
+      </span>
+      <span className="text-helper-text-sm color-text-secondary whitespace-nowrap">
+        {createdAt && dateFormatter(createdAt)}
+      </span>
+      <div className="ml-auto flex items-center gap-1">
+        {canAcceptReject && (
+          <>
+            <IconButton
+              icon="Check"
+              variant="ghost"
+              size="sm"
+              onClick={onAccept}
+              title="Accept suggestion"
+            />
+            <IconButton
+              icon="X"
+              variant="ghost"
+              size="sm"
+              onClick={onReject}
+              title="Reject suggestion"
+            />
+          </>
+        )}
+        {canWithdraw && (
+          <IconButton
+            icon="X"
+            variant="ghost"
+            size="sm"
+            onClick={onReject}
+            title="Withdraw suggestion"
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// DiffSummary — one-line suggestion description
+//   Add:     Add: "lorem"
+//   Delete:  Delete: "concepts"
+//   Replace: Replace: "concepts" with "lorem"
+// ---------------------------------------------------------------------------
+
+const DiffSummary = ({
+  comment,
+}: {
+  comment: NonNullable<ThreadFloatingCardProps['comment']>;
+}) => {
+  const {
+    suggestionType,
+    originalContent = '',
+    suggestedContent = '',
+  } = comment;
+
+  if (suggestionType === 'add') {
+    return (
+      <p className="text-body-sm">
+        <span className="font-semibold">Add:</span>{' '}
+        <span>&ldquo;{suggestedContent}&rdquo;</span>
+      </p>
+    );
+  }
+
+  if (suggestionType === 'delete') {
+    return (
+      <p className="text-body-sm">
+        <span className="font-semibold">Delete:</span>{' '}
+        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>
+      </p>
+    );
+  }
+
+  if (suggestionType === 'replace') {
+    return (
+      <p className="text-body-sm">
+        <span className="font-semibold">Replace:</span>{' '}
+        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>{' '}
+        <span className="font-semibold">with</span>{' '}
+        <span>&ldquo;{suggestedContent}&rdquo;</span>
+      </p>
+    );
+  }
+
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// RepliesList — renders existing replies under the diff summary so users see
+// their reply show up after sending (the generic CommentCard's reply renderer
+// is coupled to its thread header, so we render a compact list inline here).
+// ---------------------------------------------------------------------------
+
+const RepliesList = ({
+  comment,
+}: {
+  comment: NonNullable<ThreadFloatingCardProps['comment']>;
+}) => {
+  const replies = (comment.replies ?? []).filter((reply) => !reply.deleted);
+  if (replies.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2 pt-1">
+      {replies.map((reply) => (
+        <ReplyRow
+          key={reply.id}
+          username={reply.username}
+          createdAt={reply.createdAt}
+          content={reply.content ?? ''}
+        />
+      ))}
+    </div>
+  );
+};
+
+const ReplyRow = ({
+  username,
+  createdAt,
+  content,
+}: {
+  username: string | undefined;
+  createdAt: Date | undefined;
+  content: string;
+}) => {
+  const ensStatus = useEnsStatus(username);
+
+  return (
+    <div className="flex items-start gap-2">
+      <Avatar
+        src={
+          ensStatus.isEns
+            ? EnsLogo
+            : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
+                ensStatus.name,
+              )}`
+        }
+        size="sm"
+        className="min-w-6 mt-0.5"
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-body-sm-bold truncate">
+            {nameFormatter(ensStatus.name)}
+          </span>
+          <span className="text-helper-text-sm color-text-secondary whitespace-nowrap">
+            {createdAt && dateFormatter(createdAt)}
+          </span>
+        </div>
+        <p className="text-body-sm whitespace-pre-wrap break-words">
+          {content}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// ReplyField — same behavior as ThreadFloatingCard's reply input, scoped here
+// ---------------------------------------------------------------------------
+
+const ReplyField = ({
+  thread,
+  comment,
+}: {
+  thread: ThreadFloatingCardProps['thread'];
+  comment: NonNullable<ThreadFloatingCardProps['comment']>;
+}) => {
+  const username = useCommentStore((s) => s.username);
+  const isConnected = useCommentStore((s) => s.isConnected);
+  const handleAddReply = useCommentStore((s) => s.handleAddReply);
+  const setCommentDrawerOpen = useCommentStore((s) => s.setCommentDrawerOpen);
+  const [replyText, setReplyText] = useState('');
+  const replyTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const canReply = !comment.resolved && !comment.deleted;
+
+  useEffect(() => {
+    if (replyTextareaRef.current) {
+      resizeInlineCommentTextarea(replyTextareaRef.current);
+    }
+  }, [replyText]);
+
+  const handleSubmit = () => {
+    if (!thread.commentId || !replyText.trim()) return;
+    if (!isConnected) {
+      setCommentDrawerOpen?.(true);
+      return;
+    }
+    handleAddReply(thread.commentId, replyText);
+    setReplyText('');
+  };
+
+  if (!canReply) return null;
+
+  return (
+    <div className={cn('flex items-start gap-2 pt-1')}>
+      <Avatar
+        src={`https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
+          username ?? 'anon',
+        )}`}
+        size="sm"
+        className="min-w-6 mt-1"
+      />
+      <div className="flex-1">
+        <TextAreaFieldV2
+          ref={replyTextareaRef}
+          value={replyText}
+          onChange={(e) => setReplyText(e.target.value)}
+          placeholder="Reply"
+          className="resize-none"
+        />
+      </div>
+      <Button
+        size="sm"
+        disabled={!replyText.trim()}
+        onClick={handleSubmit}
+        className="!min-w-[64px]"
+      >
+        Send
+      </Button>
+    </div>
+  );
+};

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -4,8 +4,11 @@ import { useCommentStore } from '../../../stores/comment-store';
 import EnsLogo from '../../../assets/ens.svg';
 import verifiedMark from '../../../assets/ens-check.svg';
 import { dateFormatter, nameFormatter } from '../../../utils/helpers';
+import { CommentRepliesThread } from '../comment-card';
+import { useCommentCard } from '../use-comment-card';
 import { useEnsStatus } from '../use-ens-status';
 import { resizeInlineCommentTextarea } from '../resize-inline-comment-textarea';
+import { FloatingAuthPrompt } from './floating-auth-prompt';
 import { FloatingCardShell } from './floating-card-shell';
 import type { ThreadFloatingCardProps } from './types';
 
@@ -71,7 +74,7 @@ export const SuggestionThreadFloatingCard = ({
       isFocused={thread.isFocused}
       onFocus={handleFocus}
     >
-      <div className="flex flex-col gap-2 p-3">
+      <div className="flex flex-col gap-2 p-3 pb-0">
         <Header
           username={comment.username}
           createdAt={comment.createdAt}
@@ -80,10 +83,15 @@ export const SuggestionThreadFloatingCard = ({
           onAccept={handleAccept}
           onReject={handleReject}
         />
+        <div className="ml-[32px]">
+          <DiffSummary comment={comment} />
+        </div>
 
-        <DiffSummary comment={comment} />
-
-        <RepliesList comment={comment} />
+        <RepliesThread
+          thread={thread}
+          comment={comment}
+          onFocusRequest={handleFocus}
+        />
 
         <ReplyField thread={thread} comment={comment} />
       </div>
@@ -220,70 +228,60 @@ const DiffSummary = ({
 };
 
 // ---------------------------------------------------------------------------
-// RepliesList — renders existing replies under the diff summary so users see
-// their reply show up after sending (the generic CommentCard's reply renderer
-// is coupled to its thread header, so we render a compact list inline here).
+// RepliesThread — reuses the same collapse/toggle rendering as CommentCard so
+// floating suggestion threads stay aligned with regular thread cards.
 // ---------------------------------------------------------------------------
 
-const RepliesList = ({
+const RepliesThread = ({
+  thread,
   comment,
+  onFocusRequest,
 }: {
+  thread: ThreadFloatingCardProps['thread'];
   comment: NonNullable<ThreadFloatingCardProps['comment']>;
+  onFocusRequest: () => void;
 }) => {
-  const replies = (comment.replies ?? []).filter((reply) => !reply.deleted);
-  if (replies.length === 0) return null;
+  const {
+    commentsContainerRef,
+    displayedReplies,
+    ensStatus,
+    handleReplyToggleClick,
+    replyToggleLabel,
+    shouldShowReplyThread,
+    shouldShowReplyToggle,
+    shouldShowResolvedMobileReplyCount,
+    showAllReplies,
+    visibleReplies,
+  } = useCommentCard({
+    id: comment.id,
+    username: comment.username,
+    comment: comment.content,
+    replies: comment.replies,
+    isResolved: comment.resolved,
+    isDropdown: true,
+    isFocused: thread.isFocused,
+    onFocusRequest,
+  });
+
+  if (visibleReplies.length === 0) {
+    return null;
+  }
 
   return (
-    <div className="flex flex-col gap-2 pt-1">
-      {replies.map((reply) => (
-        <ReplyRow
-          key={reply.id}
-          username={reply.username}
-          createdAt={reply.createdAt}
-          content={reply.content ?? ''}
-        />
-      ))}
-    </div>
-  );
-};
-
-const ReplyRow = ({
-  username,
-  createdAt,
-  content,
-}: {
-  username: string | undefined;
-  createdAt: Date | undefined;
-  content: string;
-}) => {
-  const ensStatus = useEnsStatus(username);
-
-  return (
-    <div className="flex items-start gap-2">
-      <Avatar
-        src={
-          ensStatus.isEns
-            ? EnsLogo
-            : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
-                ensStatus.name,
-              )}`
-        }
-        size="sm"
-        className="min-w-6 mt-0.5"
+    <div ref={commentsContainerRef}>
+      <CommentRepliesThread
+        id={comment.id}
+        displayedReplies={displayedReplies}
+        ensStatus={ensStatus}
+        handleReplyToggleClick={handleReplyToggleClick}
+        isResolved={comment.resolved}
+        replyToggleLabel={replyToggleLabel}
+        shouldShowReplyThread={shouldShowReplyThread}
+        shouldShowReplyToggle={shouldShowReplyToggle}
+        shouldShowResolvedMobileReplyCount={shouldShowResolvedMobileReplyCount}
+        showAllReplies={showAllReplies}
+        visibleReplies={visibleReplies}
       />
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="text-body-sm-bold truncate">
-            {nameFormatter(ensStatus.name)}
-          </span>
-          <span className="text-helper-text-sm color-text-secondary whitespace-nowrap">
-            {createdAt && dateFormatter(createdAt)}
-          </span>
-        </div>
-        <p className="text-body-sm whitespace-pre-wrap break-words">
-          {content}
-        </p>
-      </div>
     </div>
   );
 };
@@ -304,11 +302,13 @@ const ReplyField = ({
   const handleAddReply = useCommentStore((s) => s.handleAddReply);
   const setCommentDrawerOpen = useCommentStore((s) => s.setCommentDrawerOpen);
   const [replyText, setReplyText] = useState('');
+  const [isReplyInputFocused, setIsReplyInputFocused] = useState(false);
   const replyTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const canReply = !comment.resolved && !comment.deleted;
   const hasUnsentReply = Boolean(replyText.trim());
   const shouldShowReplyField =
     isConnected && (thread.isFocused || hasUnsentReply);
+  const ensStatus = useEnsStatus(username);
 
   useEffect(() => {
     if (replyTextareaRef.current) {
@@ -324,36 +324,76 @@ const ReplyField = ({
     }
     handleAddReply(thread.commentId, replyText);
     setReplyText('');
+    setIsReplyInputFocused(false);
   };
 
-  if (!canReply || !shouldShowReplyField) return null;
+  if (!canReply) return null;
+
+  if (thread.isFocused && !isConnected) {
+    return <FloatingAuthPrompt />;
+  }
+
+  if (!shouldShowReplyField) return null;
 
   return (
-    <div className={cn('flex items-start gap-2 pt-1')}>
-      <Avatar
-        src={`https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
-          username ?? 'anon',
-        )}`}
-        size="sm"
-        className="min-w-6 mt-1"
-      />
-      <div className="flex-1">
+    <div className="group">
+      <div className="border flex px-[12px] py-[8px] gap-[8px] rounded-[4px] color-bg-default">
+        <Avatar
+          src={
+            ensStatus.isEns
+              ? EnsLogo
+              : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
+                  ensStatus.name || '',
+                )}`
+          }
+          className="w-[16px] h-[16px]"
+        />
         <TextAreaFieldV2
           ref={replyTextareaRef}
           value={replyText}
-          onChange={(e) => setReplyText(e.target.value)}
-          placeholder="Reply"
-          className="resize-none"
+          onChange={(event) => {
+            setReplyText(event.target.value);
+            resizeInlineCommentTextarea(event.currentTarget);
+          }}
+          onFocus={() => setIsReplyInputFocused(true)}
+          onBlur={() => setIsReplyInputFocused(false)}
+          onInput={(event) => resizeInlineCommentTextarea(event.currentTarget)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && (!event.shiftKey || event.metaKey)) {
+              event.preventDefault();
+              handleSubmit();
+            }
+          }}
+          className="color-bg-default w-full text-body-sm color-text-default !p-0 !border-none h-[20px] max-h-[296px] overflow-y-auto no-scrollbar whitespace-pre-wrap"
+          placeholder={canReply ? 'Add a reply' : 'Thread resolved'}
+          disabled={!canReply}
         />
       </div>
-      <Button
-        size="sm"
-        disabled={!replyText.trim()}
-        onClick={handleSubmit}
-        className="!min-w-[64px]"
+      <div
+        className={cn(
+          'items-center justify-end gap-2 pt-2',
+          hasUnsentReply || isReplyInputFocused ? 'flex' : 'hidden',
+        )}
       >
-        Send
-      </Button>
+        <Button
+          variant="ghost"
+          className="w-20 min-w-20"
+          onClick={(event) => {
+            event.stopPropagation();
+            setReplyText('');
+            setIsReplyInputFocused(false);
+          }}
+        >
+          <p className="text-body-sm-bold">Cancel</p>
+        </Button>
+        <Button
+          className="w-20 min-w-20"
+          disabled={!replyText.trim()}
+          onClick={handleSubmit}
+        >
+          Send
+        </Button>
+      </div>
     </div>
   );
 };

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -1,5 +1,5 @@
 import { Avatar, Button, IconButton, TextAreaFieldV2, cn } from '@fileverse/ui';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useCommentStore } from '../../../stores/comment-store';
 import EnsLogo from '../../../assets/ens.svg';
 import verifiedMark from '../../../assets/ens-check.svg';
@@ -36,6 +36,12 @@ export const SuggestionThreadFloatingCard = ({
   const currentUsername = useCommentStore((s) => s.username);
   const acceptSuggestion = useCommentStore((s) => s.acceptSuggestion);
   const deleteComment = useCommentStore((s) => s.deleteComment);
+  const handleCardNode = useCallback(
+    (node: HTMLDivElement | null) => {
+      registerCardNode(thread.floatingCardId, node);
+    },
+    [registerCardNode, thread.floatingCardId],
+  );
 
   if (!comment) return null;
 
@@ -68,7 +74,7 @@ export const SuggestionThreadFloatingCard = ({
 
   return (
     <FloatingCardShell
-      ref={(node) => registerCardNode(thread.floatingCardId, node)}
+      ref={handleCardNode}
       floatingCardId={thread.floatingCardId}
       isHidden={isHidden}
       isFocused={thread.isFocused}
@@ -146,7 +152,7 @@ const Header = ({
       <span className="text-helper-text-sm color-text-secondary whitespace-nowrap">
         {createdAt && dateFormatter(createdAt)}
       </span>
-      <div className="ml-auto opacity-0 group-hover:opacity-100 items-center gap-1">
+      <div className="ml-auto opacity-0 group-hover:opacity-100 flex items-center gap-1">
         {canAcceptReject && (
           <>
             <IconButton

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -38,6 +38,7 @@ export const SuggestionThreadFloatingCard = ({
 
   const handleFocus = () => {
     focusFloatingCard(thread.floatingCardId);
+
     if (!thread.isFocused && thread.commentId) {
       focusCommentInEditor(thread.commentId);
     }
@@ -305,6 +306,9 @@ const ReplyField = ({
   const [replyText, setReplyText] = useState('');
   const replyTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const canReply = !comment.resolved && !comment.deleted;
+  const hasUnsentReply = Boolean(replyText.trim());
+  const shouldShowReplyField =
+    isConnected && (thread.isFocused || hasUnsentReply);
 
   useEffect(() => {
     if (replyTextareaRef.current) {
@@ -322,7 +326,7 @@ const ReplyField = ({
     setReplyText('');
   };
 
-  if (!canReply) return null;
+  if (!canReply || !shouldShowReplyField) return null;
 
   return (
     <div className={cn('flex items-start gap-2 pt-1')}>

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -74,7 +74,7 @@ export const SuggestionThreadFloatingCard = ({
       isFocused={thread.isFocused}
       onFocus={handleFocus}
     >
-      <div className="flex flex-col gap-2 p-3 pb-0">
+      <div className="flex group flex-col gap-2 p-3 pb-0">
         <Header
           username={comment.username}
           createdAt={comment.createdAt}
@@ -144,7 +144,7 @@ const Header = ({
       <span className="text-helper-text-sm color-text-secondary whitespace-nowrap">
         {createdAt && dateFormatter(createdAt)}
       </span>
-      <div className="ml-auto flex items-center gap-1">
+      <div className="ml-auto opacity-0 group-hover:opacity-100 items-center gap-1">
         {canAcceptReject && (
           <>
             <IconButton

--- a/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/suggestion-thread-floating-card.tsx
@@ -197,7 +197,7 @@ const DiffSummary = ({
 
   if (suggestionType === 'add') {
     return (
-      <p className="text-body-sm">
+      <p className="text-body-sm break-words">
         <span className="font-semibold">Add:</span>{' '}
         <span>&ldquo;{suggestedContent}&rdquo;</span>
       </p>
@@ -206,7 +206,7 @@ const DiffSummary = ({
 
   if (suggestionType === 'delete') {
     return (
-      <p className="text-body-sm">
+      <p className="text-body-sm break-words">
         <span className="font-semibold">Delete:</span>{' '}
         <span className="line-through">&ldquo;{originalContent}&rdquo;</span>
       </p>
@@ -215,11 +215,20 @@ const DiffSummary = ({
 
   if (suggestionType === 'replace') {
     return (
-      <p className="text-body-sm">
+      <p className="text-body-sm break-words">
         <span className="font-semibold">Replace:</span>{' '}
         <span className="line-through">&ldquo;{originalContent}&rdquo;</span>{' '}
         <span className="font-semibold">with</span>{' '}
         <span>&ldquo;{suggestedContent}&rdquo;</span>
+      </p>
+    );
+  }
+
+  if (suggestionType === 'link') {
+    return (
+      <p className="text-body-sm break-words">
+        <span className="font-semibold">Add link:</span>{' '}
+        <span>&quot;{suggestedContent}&quot;</span>
       </p>
     );
   }

--- a/package/components/inline-comment/floating-comment/thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/thread-floating-card.tsx
@@ -99,11 +99,14 @@ export const ThreadFloatingCard = ({
         {thread.isFocused && !isConnected && !isCollaborationEnabled && (
           <FloatingAuthPrompt />
         )}
-        <InputField
-          comment={comment}
-          thread={thread}
-          isCollaborationEnabled={isCollaborationEnabled}
-        />
+        <div className="px-3">
+          <InputField
+            comment={comment}
+            thread={thread}
+            isCollaborationEnabled={isCollaborationEnabled}
+          />
+        </div>
+
         <DeleteConfirmOverlay
           isVisible={isDeleteOverlayVisible}
           title="Delete this comment thread ?"
@@ -224,7 +227,7 @@ const InputField = ({
 
   if (!shouldShowReplyInputField) return;
   return (
-    <div className="group p-3 pt-0 pb-0">
+    <div className="group">
       <div
         className={cn(
           'border flex px-[12px] py-[8px] gap-[8px] rounded-[4px]',

--- a/package/components/inline-comment/floating-comment/thread-floating-card.tsx
+++ b/package/components/inline-comment/floating-comment/thread-floating-card.tsx
@@ -1,5 +1,5 @@
 import { Avatar, Button, cn, TextAreaFieldV2 } from '@fileverse/ui';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useCommentStore } from '../../../stores/comment-store';
 import { CommentCard } from '../comment-card';
 import { DeleteConfirmOverlay } from '../delete-confirm-overlay';
@@ -59,10 +59,16 @@ export const ThreadFloatingCard = ({
       focusCommentInEditor(thread.commentId);
     }
   };
+  const handleCardNode = useCallback(
+    (node: HTMLDivElement | null) => {
+      registerCardNode(thread.floatingCardId, node);
+    },
+    [registerCardNode, thread.floatingCardId],
+  );
 
   return (
     <FloatingCardShell
-      ref={(node) => registerCardNode(thread.floatingCardId, node)}
+      ref={handleCardNode}
       floatingCardId={thread.floatingCardId}
       isHidden={isHidden}
       isFocused={thread.isFocused}

--- a/package/components/inline-comment/floating-comment/types.ts
+++ b/package/components/inline-comment/floating-comment/types.ts
@@ -4,6 +4,7 @@ import type { IComment } from '../../../extensions/comment';
 import type {
   CommentFloatingDraftCard,
   CommentFloatingThreadCard,
+  SuggestionFloatingDraftCard,
 } from '../context/types';
 
 export type RegisterCardNode = (
@@ -41,4 +42,10 @@ export interface ThreadFloatingCardProps {
   isHidden: boolean;
   registerCardNode: RegisterCardNode;
   isCollaborationEnabled?: boolean;
+}
+
+export interface SuggestionDraftFloatingCardProps {
+  card: SuggestionFloatingDraftCard;
+  isHidden: boolean;
+  registerCardNode: RegisterCardNode;
 }

--- a/package/components/inline-comment/mobile-inline-comment-sheet.tsx
+++ b/package/components/inline-comment/mobile-inline-comment-sheet.tsx
@@ -1,0 +1,96 @@
+import { useRef } from 'react';
+import { Avatar, IconButton, TextAreaFieldV2 } from '@fileverse/ui';
+import { DeleteConfirmOverlay } from './delete-confirm-overlay';
+import { resizeInlineCommentTextarea } from './resize-inline-comment-textarea';
+import type { InlineCommentDraft } from './context/types';
+
+interface MobileInlineCommentProps {
+  activeDraft: InlineCommentDraft | null;
+  activeDraftId: string | null;
+  isDiscardCommentOverlayVisible: boolean;
+  mobileDraftRef: React.RefObject<HTMLDivElement>;
+  onAttemptClose: () => void;
+  onCancelDiscard: () => void;
+  onConfirmDiscard: () => void;
+  onSubmit: () => void;
+  onUpdateDraftText: (draftId: string, text: string) => void;
+}
+
+export const MobileInlineComment = ({
+  activeDraft,
+  activeDraftId,
+  isDiscardCommentOverlayVisible,
+  mobileDraftRef,
+  onAttemptClose,
+  onCancelDiscard,
+  onConfirmDiscard,
+  onSubmit,
+  onUpdateDraftText,
+}: MobileInlineCommentProps) => {
+  const mobileDraftTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  return (
+    <div
+      ref={mobileDraftRef}
+      data-mobile-comment-drawer-sheet
+      className="p-4 rounded-t-[12px] shadow-[0_-12px_32px_rgba(0,0,0,0.18)] w-full color-bg-secondary"
+    >
+      <div className="flex justify-between mb-[16px] items-center">
+        <h2 className="text-heading-sm">New Comment</h2>
+        <div className="flex gap-sm">
+          <IconButton
+            onClick={onAttemptClose}
+            icon={'X'}
+            variant="ghost"
+            size="md"
+          />
+        </div>
+      </div>
+      <div className="border flex px-[12px] items-center justify-between py-[8px] gap-[8px] rounded-[4px]">
+        <Avatar
+          src={`https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
+            '',
+          )}`}
+          className="w-[16px] h-[16px]"
+        />
+        <TextAreaFieldV2
+          ref={mobileDraftTextareaRef}
+          value={activeDraft?.text || ''}
+          autoFocus
+          onChange={(event) => {
+            if (activeDraftId) {
+              onUpdateDraftText(activeDraftId, event.target.value);
+            }
+
+            resizeInlineCommentTextarea(event.currentTarget);
+          }}
+          onInput={(event) => resizeInlineCommentTextarea(event.currentTarget)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && (!event.shiftKey || event.metaKey)) {
+              event.preventDefault();
+              onSubmit();
+            }
+          }}
+          className="color-bg-default w-full text-body-sm color-text-default !p-0 !border-none h-[20px] max-h-[296px] overflow-y-auto no-scrollbar whitespace-pre-wrap"
+          placeholder="Add a comment"
+        />
+        <IconButton
+          onClick={onSubmit}
+          icon={'SendHorizontal'}
+          variant="ghost"
+          disabled={!activeDraft?.text.trim()}
+          className="!min-w-[24px] !w-[24px] !min-h-[24px] !h-[24px]"
+        />
+      </div>
+      <DeleteConfirmOverlay
+        isVisible={isDiscardCommentOverlayVisible}
+        title="Discard comment"
+        heading="Discard comment"
+        description="This action will discard your comment."
+        confirmLabel="Discard"
+        onCancel={onCancelDiscard}
+        onConfirm={onConfirmDiscard}
+      />
+    </div>
+  );
+};

--- a/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
+++ b/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
@@ -41,6 +41,8 @@ export const MobileSuggestionDraft = ({
     : hasSuggestionInserted
       ? 'add'
       : null;
+  const interactiveSelector =
+    'button, input, textarea, select, [contenteditable="true"], [role="textbox"]';
 
   return (
     <div
@@ -53,7 +55,7 @@ export const MobileSuggestionDraft = ({
 
         const target = event.target as HTMLElement;
 
-        if (target.closest('button')) {
+        if (target.closest(interactiveSelector)) {
           return;
         }
 

--- a/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
+++ b/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
@@ -6,6 +6,7 @@ import EnsLogo from '../../assets/ens.svg';
 import verifiedMark from '../../assets/ens-check.svg';
 import { dateFormatter, nameFormatter } from '../../utils/helpers';
 import type { SuggestionFloatingDraftCard } from './context/types';
+import { SuggestionDiffSummary } from './suggestion-diff-summary';
 
 interface MobileSuggestionDraftProps {
   activeSuggestionDraftCard: SuggestionFloatingDraftCard;
@@ -109,45 +110,15 @@ export const MobileSuggestionDraft = ({
           </div>
 
           <div className="text-body-sm color-text-default ml-[32px] break-words">
-            {suggestionType === 'add' && (
-              <p>
-                <span className="font-semibold">Add:</span>{' '}
-                <span>
-                  &ldquo;{activeSuggestionDraftCard.insertedText}&rdquo;
-                </span>
-              </p>
-            )}
-            {suggestionType === 'delete' && (
-              <p>
-                <span className="font-semibold">Delete:</span>{' '}
-                <span className="line-through">
-                  &ldquo;{activeSuggestionDraftCard.selectedText}&rdquo;
-                </span>
-              </p>
-            )}
-            {suggestionType === 'replace' && (
-              <p>
-                <span className="font-semibold">Replace:</span>{' '}
-                <span className="line-through">
-                  &ldquo;{activeSuggestionDraftCard.selectedText}&rdquo;
-                </span>{' '}
-                <span className="font-semibold">with</span>{' '}
-                <span>
-                  &ldquo;{activeSuggestionDraftCard.insertedText}&rdquo;
-                </span>
-              </p>
-            )}
-            {suggestionType === 'link' && (
-              <p>
-                <span className="font-semibold">Add link:</span>{' '}
-                <span>&quot;{activeSuggestionDraftCard.linkHref}&quot;</span>
-              </p>
-            )}
-            {!suggestionType && (
-              <p className="color-text-secondary italic">
-                Start typing to suggest a change
-              </p>
-            )}
+            <SuggestionDiffSummary
+              suggestionType={suggestionType}
+              originalContent={activeSuggestionDraftCard.selectedText}
+              suggestedContent={
+                activeSuggestionDraftCard.linkHref ??
+                activeSuggestionDraftCard.insertedText
+              }
+              emptyText="Start typing to suggest a change"
+            />
           </div>
 
           <div className="flex items-center justify-end">

--- a/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
+++ b/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
@@ -33,14 +33,18 @@ export const MobileSuggestionDraft = ({
   const ensStatus = useEnsStatus(username);
   const hasSuggestionOriginal = Boolean(activeSuggestionDraftCard.selectedText);
   const hasSuggestionInserted = Boolean(activeSuggestionDraftCard.insertedText);
-  const canSubmitSuggestion = hasSuggestionOriginal || hasSuggestionInserted;
-  const suggestionType = hasSuggestionOriginal
-    ? hasSuggestionInserted
-      ? 'replace'
-      : 'delete'
-    : hasSuggestionInserted
-      ? 'add'
-      : null;
+  const hasSuggestionLink = Boolean(activeSuggestionDraftCard.linkHref);
+  const canSubmitSuggestion =
+    hasSuggestionOriginal || hasSuggestionInserted || hasSuggestionLink;
+  const suggestionType = hasSuggestionLink
+    ? 'link'
+    : hasSuggestionOriginal
+      ? hasSuggestionInserted
+        ? 'replace'
+        : 'delete'
+      : hasSuggestionInserted
+        ? 'add'
+        : null;
   const interactiveSelector =
     'button, input, textarea, select, [contenteditable="true"], [role="textbox"]';
 
@@ -131,6 +135,12 @@ export const MobileSuggestionDraft = ({
                 <span>
                   &ldquo;{activeSuggestionDraftCard.insertedText}&rdquo;
                 </span>
+              </p>
+            )}
+            {suggestionType === 'link' && (
+              <p>
+                <span className="font-semibold">Add link:</span>{' '}
+                <span>&quot;{activeSuggestionDraftCard.linkHref}&quot;</span>
               </p>
             )}
             {!suggestionType && (

--- a/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
+++ b/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
@@ -1,0 +1,149 @@
+import { Avatar, Button, IconButton } from '@fileverse/ui';
+import { DeleteConfirmOverlay } from './delete-confirm-overlay';
+import { FloatingAuthPrompt } from './floating-comment/floating-auth-prompt';
+import { useEnsStatus } from './use-ens-status';
+import EnsLogo from '../../assets/ens.svg';
+import verifiedMark from '../../assets/ens-check.svg';
+import { dateFormatter, nameFormatter } from '../../utils/helpers';
+import type { SuggestionFloatingDraftCard } from './context/types';
+
+interface MobileSuggestionDraftProps {
+  activeSuggestionDraftCard: SuggestionFloatingDraftCard;
+  isConnected: boolean;
+  isDiscardSuggestionOverlayVisible: boolean;
+  username: string | null;
+  onAttemptClose: () => void;
+  onCancelDiscard: () => void;
+  onConfirmDiscard: () => void;
+  onSubmit: () => void;
+}
+
+export const MobileSuggestionDraft = ({
+  activeSuggestionDraftCard,
+  isConnected,
+  isDiscardSuggestionOverlayVisible,
+  username,
+  onAttemptClose,
+  onCancelDiscard,
+  onConfirmDiscard,
+  onSubmit,
+}: MobileSuggestionDraftProps) => {
+  const ensStatus = useEnsStatus(username);
+  const hasSuggestionOriginal = Boolean(activeSuggestionDraftCard.selectedText);
+  const hasSuggestionInserted = Boolean(activeSuggestionDraftCard.insertedText);
+  const canSubmitSuggestion = hasSuggestionOriginal || hasSuggestionInserted;
+  const suggestionType = hasSuggestionOriginal
+    ? hasSuggestionInserted
+      ? 'replace'
+      : 'delete'
+    : hasSuggestionInserted
+      ? 'add'
+      : null;
+
+  return (
+    <div
+      data-mobile-comment-drawer-sheet
+      className="p-4 rounded-t-[12px] shadow-[0_-12px_32px_rgba(0,0,0,0.18)] w-full color-bg-secondary"
+    >
+      <div className="flex justify-between mb-[16px] items-center">
+        <h2 className="text-heading-sm">New Suggestion</h2>
+        <div className="flex gap-sm">
+          <IconButton
+            onClick={onAttemptClose}
+            icon={'X'}
+            variant="ghost"
+            size="md"
+          />
+        </div>
+      </div>
+      {!isConnected ? (
+        <FloatingAuthPrompt />
+      ) : (
+        <div className="flex flex-col gap-[8px]">
+          <div className="flex items-center gap-2">
+            <Avatar
+              src={
+                ensStatus.isEns
+                  ? EnsLogo
+                  : `https://api.dicebear.com/9.x/identicon/svg?seed=${encodeURIComponent(
+                      ensStatus.name,
+                    )}`
+              }
+              size="sm"
+              className="min-w-6"
+            />
+            <span className="text-body-sm-bold inline-flex items-center gap-1 min-w-0">
+              <span className="truncate">{nameFormatter(ensStatus.name)}</span>
+              {ensStatus.isEns && (
+                <img
+                  src={verifiedMark}
+                  alt="verified"
+                  className="w-3.5 h-3.5"
+                />
+              )}
+            </span>
+            <span className="text-helper-text-sm color-text-secondary whitespace-nowrap">
+              {dateFormatter(Date.now())}
+            </span>
+          </div>
+
+          <div className="text-body-sm color-text-default ml-[32px] break-words">
+            {suggestionType === 'add' && (
+              <p>
+                <span className="font-semibold">Add:</span>{' '}
+                <span>
+                  &ldquo;{activeSuggestionDraftCard.insertedText}&rdquo;
+                </span>
+              </p>
+            )}
+            {suggestionType === 'delete' && (
+              <p>
+                <span className="font-semibold">Delete:</span>{' '}
+                <span className="line-through">
+                  &ldquo;{activeSuggestionDraftCard.selectedText}&rdquo;
+                </span>
+              </p>
+            )}
+            {suggestionType === 'replace' && (
+              <p>
+                <span className="font-semibold">Replace:</span>{' '}
+                <span className="line-through">
+                  &ldquo;{activeSuggestionDraftCard.selectedText}&rdquo;
+                </span>{' '}
+                <span className="font-semibold">with</span>{' '}
+                <span>
+                  &ldquo;{activeSuggestionDraftCard.insertedText}&rdquo;
+                </span>
+              </p>
+            )}
+            {!suggestionType && (
+              <p className="color-text-secondary italic">
+                Start typing to suggest a change
+              </p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-end">
+            <Button
+              size="sm"
+              disabled={!canSubmitSuggestion}
+              onClick={onSubmit}
+              className="!min-w-[80px]"
+            >
+              Submit
+            </Button>
+          </div>
+        </div>
+      )}
+      <DeleteConfirmOverlay
+        isVisible={isDiscardSuggestionOverlayVisible}
+        title="Discard suggestion"
+        heading="Discard suggestion"
+        description="This action will discard your suggestion."
+        confirmLabel="Discard"
+        onCancel={onCancelDiscard}
+        onConfirm={onConfirmDiscard}
+      />
+    </div>
+  );
+};

--- a/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
+++ b/package/components/inline-comment/mobile-suggestion-draft-sheet.tsx
@@ -15,6 +15,7 @@ interface MobileSuggestionDraftProps {
   onAttemptClose: () => void;
   onCancelDiscard: () => void;
   onConfirmDiscard: () => void;
+  onFocusSuggestionText: () => void;
   onSubmit: () => void;
 }
 
@@ -26,6 +27,7 @@ export const MobileSuggestionDraft = ({
   onAttemptClose,
   onCancelDiscard,
   onConfirmDiscard,
+  onFocusSuggestionText,
   onSubmit,
 }: MobileSuggestionDraftProps) => {
   const ensStatus = useEnsStatus(username);
@@ -44,6 +46,19 @@ export const MobileSuggestionDraft = ({
     <div
       data-mobile-comment-drawer-sheet
       className="p-4 rounded-t-[12px] shadow-[0_-12px_32px_rgba(0,0,0,0.18)] w-full color-bg-secondary"
+      onClick={(event) => {
+        if (isDiscardSuggestionOverlayVisible) {
+          return;
+        }
+
+        const target = event.target as HTMLElement;
+
+        if (target.closest('button')) {
+          return;
+        }
+
+        onFocusSuggestionText();
+      }}
     >
       <div className="flex justify-between mb-[16px] items-center">
         <h2 className="text-heading-sm">New Suggestion</h2>

--- a/package/components/inline-comment/suggestion-diff-summary.tsx
+++ b/package/components/inline-comment/suggestion-diff-summary.tsx
@@ -1,0 +1,68 @@
+import { cn } from '@fileverse/ui';
+import type { SuggestionType } from '../../types';
+
+interface SuggestionDiffSummaryProps {
+  suggestionType?: SuggestionType | null;
+  originalContent?: string;
+  suggestedContent?: string;
+  emptyText?: string;
+  className?: string;
+}
+
+export const SuggestionDiffSummary = ({
+  suggestionType,
+  originalContent = '',
+  suggestedContent = '',
+  emptyText,
+  className,
+}: SuggestionDiffSummaryProps) => {
+  const summaryClassName = cn('text-body-sm break-words', className);
+
+  if (suggestionType === 'add') {
+    return (
+      <p className={summaryClassName}>
+        <span className="font-semibold">Add:</span>{' '}
+        <span>&ldquo;{suggestedContent}&rdquo;</span>
+      </p>
+    );
+  }
+
+  if (suggestionType === 'delete') {
+    return (
+      <p className={summaryClassName}>
+        <span className="font-semibold">Delete:</span>{' '}
+        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>
+      </p>
+    );
+  }
+
+  if (suggestionType === 'replace') {
+    return (
+      <p className={summaryClassName}>
+        <span className="font-semibold">Replace:</span>{' '}
+        <span className="line-through">&ldquo;{originalContent}&rdquo;</span>{' '}
+        <span className="font-semibold">with</span>{' '}
+        <span>&ldquo;{suggestedContent}&rdquo;</span>
+      </p>
+    );
+  }
+
+  if (suggestionType === 'link') {
+    return (
+      <p className={summaryClassName}>
+        <span className="font-semibold">Add link:</span>{' '}
+        <span>&quot;{suggestedContent}&quot;</span>
+      </p>
+    );
+  }
+
+  if (emptyText) {
+    return (
+      <p className={cn(summaryClassName, 'color-text-secondary italic')}>
+        {emptyText}
+      </p>
+    );
+  }
+
+  return null;
+};

--- a/package/components/inline-comment/types.ts
+++ b/package/components/inline-comment/types.ts
@@ -53,6 +53,7 @@ export interface CommentCardProps extends IComment {
   activeCommentId?: string;
   isDisabled?: boolean;
   isCommentOwner?: boolean;
+  canResolveComment?: boolean;
   version?: string;
   emptyComment?: boolean;
   isFocused?: boolean;

--- a/package/components/inline-comment/use-comment-drawer-drafts.ts
+++ b/package/components/inline-comment/use-comment-drawer-drafts.ts
@@ -1,0 +1,113 @@
+import { useCallback, useState } from 'react';
+import { useCommentStore } from '../../stores/comment-store';
+import type { SuggestionFloatingDraftCard } from './context/types';
+
+interface UseCommentDrawerDraftsProps {
+  selectedCommentTabId: string;
+  setOpenReplyId: (commentId: string | null) => void;
+}
+
+export const useCommentDrawerDrafts = ({
+  selectedCommentTabId,
+  setOpenReplyId,
+}: UseCommentDrawerDraftsProps) => {
+  const activeDraftId = useCommentStore((s) => s.activeDraftId);
+  const activeDraft = useCommentStore((s) =>
+    s.activeDraftId ? (s.inlineDrafts[s.activeDraftId] ?? null) : null,
+  );
+  const activeSuggestionDraftCard = useCommentStore(
+    (s) =>
+      s.floatingCards.find(
+        (card): card is SuggestionFloatingDraftCard =>
+          card.type === 'suggestion-draft' && card.isFocused,
+      ) ??
+      s.floatingCards.find(
+        (card): card is SuggestionFloatingDraftCard =>
+          card.type === 'suggestion-draft',
+      ) ??
+      null,
+  );
+  const createFloatingDraft = useCommentStore((s) => s.createFloatingDraft);
+  const discardDraft = useCommentStore((s) => s.discardDraft);
+  const setCommentDrawerOpen = useCommentStore((s) => s.setCommentDrawerOpen);
+  const submitDraft = useCommentStore((s) => s.submitDraft);
+  const submitInlineDraft = useCommentStore((s) => s.submitInlineDraft);
+  const updateInlineDraftText = useCommentStore((s) => s.updateInlineDraftText);
+  const [isDiscardCommentOverlayVisible, setIsDiscardCommentOverlayVisible] =
+    useState(false);
+  const [
+    isDiscardSuggestionOverlayVisible,
+    setIsDiscardSuggestionOverlayVisible,
+  ] = useState(false);
+
+  // Drawer new-comment state is derived from shared draft state so mobile and desktop
+  // follow the same draft lifecycle instead of shadowing it with local UI state.
+  const isInlineDraftOpen =
+    activeDraft !== null &&
+    activeDraftId !== null &&
+    activeDraft.location === 'drawer' &&
+    // Auth-pending drafts intentionally fall back to the non-draft drawer route so
+    // mobile can show the auth screen without discarding the tracked draft.
+    !activeDraft.isAuthPending;
+
+  const handleCreateComment = useCallback(() => {
+    if (!activeDraftId) {
+      return;
+    }
+
+    // Submit the shared draft record instead of reading live editor selection.
+    submitInlineDraft(activeDraftId);
+  }, [activeDraftId, submitInlineDraft]);
+
+  const handleSubmitSuggestionDraft = useCallback(() => {
+    if (!activeSuggestionDraftCard) {
+      return;
+    }
+
+    setIsDiscardSuggestionOverlayVisible(false);
+    submitDraft(activeSuggestionDraftCard.suggestionId);
+    setOpenReplyId(null);
+    setCommentDrawerOpen?.(true);
+  }, [
+    activeSuggestionDraftCard,
+    setCommentDrawerOpen,
+    setOpenReplyId,
+    submitDraft,
+  ]);
+
+  const handleDiscardSuggestionDraft = useCallback(() => {
+    if (!activeSuggestionDraftCard) {
+      return;
+    }
+
+    setIsDiscardSuggestionOverlayVisible(false);
+    discardDraft(activeSuggestionDraftCard.suggestionId);
+  }, [activeSuggestionDraftCard, discardDraft]);
+
+  const handleStartNewMobileComment = useCallback(() => {
+    // The mobile drawer supports top-level comments
+    // Keep this drawer-scoped so floating inline comments remain
+    // anchored to an explicit editor range.
+    createFloatingDraft({
+      location: 'drawer',
+      allowEmptySelection: true,
+      tabId: selectedCommentTabId,
+    });
+  }, [createFloatingDraft, selectedCommentTabId]);
+
+  return {
+    activeDraft,
+    activeDraftId,
+    activeSuggestionDraftCard,
+    handleCreateComment,
+    handleDiscardSuggestionDraft,
+    handleStartNewMobileComment,
+    handleSubmitSuggestionDraft,
+    isDiscardCommentOverlayVisible,
+    isDiscardSuggestionOverlayVisible,
+    isInlineDraftOpen,
+    setIsDiscardCommentOverlayVisible,
+    setIsDiscardSuggestionOverlayVisible,
+    updateInlineDraftText,
+  };
+};

--- a/package/components/inline-comment/use-comment-drawer-filters.ts
+++ b/package/components/inline-comment/use-comment-drawer-filters.ts
@@ -1,0 +1,121 @@
+import { useCallback, useState } from 'react';
+import type { IComment } from '../../extensions/comment';
+import type { Tab } from '../tabs/utils/tab-utils';
+import { DEFAULT_TAB_ID, DEFAULT_TAB_NAME } from '../tabs/utils/tab-utils';
+import { ALL_TABS_OPTION_ID } from './comment-drawer-constants';
+
+export const commentTypeOptions = [
+  { id: 'all', label: 'All types' },
+  { id: 'active', label: 'Active' },
+  { id: 'resolved', label: 'Resolved' },
+];
+
+interface UseCommentDrawerFiltersProps {
+  activeTabId: string;
+  comments: IComment[];
+  tabs: Tab[];
+}
+
+export const useCommentDrawerFilters = ({
+  activeTabId,
+  comments,
+  tabs,
+}: UseCommentDrawerFiltersProps) => {
+  const [commentType, setCommentType] = useState('active');
+  const [tab, setTab] = useState(ALL_TABS_OPTION_ID);
+  const [isCommentTypeSelectOpen, setIsCommentTypeSelectOpen] = useState(false);
+  const [isTabSelectOpen, setIsTabSelectOpen] = useState(false);
+
+  const resolvedTabs =
+    tabs.length > 0
+      ? tabs
+      : [{ id: DEFAULT_TAB_ID, name: DEFAULT_TAB_NAME, emoji: null }];
+  const tabList = [
+    { id: ALL_TABS_OPTION_ID, label: 'All tabs' },
+    ...resolvedTabs.map((tabOption) => ({
+      id: tabOption.id,
+      label: tabOption.name,
+    })),
+  ];
+  const tabNameById = Object.fromEntries(
+    resolvedTabs.map((tabOption) => [tabOption.id, tabOption.name]),
+  );
+  const selectedCommentTabId = tab === ALL_TABS_OPTION_ID ? activeTabId : tab;
+  const selectedTabLabel =
+    tabList.find((tabOption) => tabOption.id === tab)?.label ??
+    DEFAULT_TAB_NAME;
+
+  const filteredComments = comments.filter((comment) => {
+    const commentTabId = comment.tabId || DEFAULT_TAB_ID;
+    const matchesTab = tab === ALL_TABS_OPTION_ID || commentTabId === tab;
+
+    if (!matchesTab || comment.deleted) {
+      return false;
+    }
+
+    if (commentType === 'active') {
+      return !comment.resolved;
+    }
+
+    if (commentType === 'resolved') {
+      return Boolean(comment.resolved);
+    }
+
+    return true;
+  });
+
+  const sectionLabel =
+    commentType === 'resolved'
+      ? 'Resolved'
+      : commentType === 'all'
+        ? 'All comments'
+        : 'Active';
+
+  const handleCommentTypeSelectOpenChange = useCallback((open: boolean) => {
+    setIsCommentTypeSelectOpen(open);
+
+    if (open) {
+      setIsTabSelectOpen(false);
+    }
+  }, []);
+
+  const handleTabSelectOpenChange = useCallback((open: boolean) => {
+    setIsTabSelectOpen(open);
+
+    if (open) {
+      setIsCommentTypeSelectOpen(false);
+    }
+  }, []);
+
+  const resetFilters = useCallback(() => {
+    // Reset both filters so the empty state can always recover
+    // to the full drawer list instead of staying tab-scoped.
+    setCommentType('all');
+    setTab(ALL_TABS_OPTION_ID);
+  }, []);
+
+  const closeFilterSelects = useCallback(() => {
+    setIsCommentTypeSelectOpen(false);
+    setIsTabSelectOpen(false);
+  }, []);
+
+  return {
+    closeFilterSelects,
+    commentType,
+    commentTypeOptions,
+    filteredComments,
+    handleCommentTypeSelectOpenChange,
+    handleTabSelectOpenChange,
+    isCommentTypeSelectOpen,
+    isTabSelectOpen,
+    resetFilters,
+    sectionLabel,
+    selectedCommentTabId,
+    selectedTab: tab,
+    selectedTabLabel,
+    setCommentType,
+    setTab,
+    tabList,
+    tabNameById,
+  };
+};

--- a/package/components/inline-comment/use-comment-drawer-focus.ts
+++ b/package/components/inline-comment/use-comment-drawer-focus.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { IComment } from '../../extensions/comment';
+import { DEFAULT_TAB_ID } from '../tabs/utils/tab-utils';
+
+interface UseCommentDrawerFocusProps {
+  activeTabId: string;
+  comments: IComment[];
+  focusCommentInEditor: (
+    commentId: string,
+    options?: { source?: 'explicit-ui' },
+  ) => void;
+  isBelow1280px: boolean;
+  onTabChange?: (tabId: string) => void;
+  setOpenReplyId: (commentId: string | null) => void;
+}
+
+export const useCommentDrawerFocus = ({
+  activeTabId,
+  comments,
+  focusCommentInEditor,
+  isBelow1280px,
+  onTabChange,
+  setOpenReplyId,
+}: UseCommentDrawerFocusProps) => {
+  const [pendingCommentFocus, setPendingCommentFocus] = useState<{
+    commentId: string;
+    tabId: string;
+  } | null>(null);
+
+  const handleCommentFocus = useCallback(
+    (commentId: string, commentTabId?: string) => {
+      const targetTabId = commentTabId || DEFAULT_TAB_ID;
+
+      if (targetTabId !== activeTabId) {
+        // Cross-tab thread clicks should not silently no-op. Switch tabs first,
+        // then replay the requested focus once the target tab is active.
+        setPendingCommentFocus({ commentId, tabId: targetTabId });
+        onTabChange?.(targetTabId);
+        return;
+      }
+
+      focusCommentInEditor(
+        commentId,
+        isBelow1280px ? undefined : { source: 'explicit-ui' },
+      );
+    },
+    [activeTabId, focusCommentInEditor, isBelow1280px, onTabChange],
+  );
+
+  useEffect(() => {
+    if (
+      !pendingCommentFocus ||
+      pendingCommentFocus.tabId !== activeTabId ||
+      !comments.some(
+        (comment) =>
+          comment.id === pendingCommentFocus.commentId &&
+          (comment.tabId || DEFAULT_TAB_ID) === activeTabId,
+      )
+    ) {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      // Wait a frame so the tab switch can mount the matching comment nodes
+      // before trying to focus/scroll them in the editor.
+      setOpenReplyId(pendingCommentFocus.commentId);
+      focusCommentInEditor(
+        pendingCommentFocus.commentId,
+        isBelow1280px ? undefined : { source: 'explicit-ui' },
+      );
+      setPendingCommentFocus(null);
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [
+    activeTabId,
+    comments,
+    focusCommentInEditor,
+    isBelow1280px,
+    pendingCommentFocus,
+    setOpenReplyId,
+  ]);
+
+  const clearPendingCommentFocus = useCallback(
+    () => setPendingCommentFocus(null),
+    [],
+  );
+
+  return {
+    clearPendingCommentFocus,
+    handleCommentFocus,
+  };
+};

--- a/package/components/inline-comment/use-comment-drawer-lifecycle.ts
+++ b/package/components/inline-comment/use-comment-drawer-lifecycle.ts
@@ -1,0 +1,79 @@
+import { useEffect } from 'react';
+import { useEscapeKey } from '../../hooks/useEscapeKey';
+import { clearMobileCommentDrawerCanvasOffset } from '../../utils/comment-scroll-into-view';
+
+interface UseCommentDrawerLifecycleProps {
+  activeSuggestionDraftCard: unknown;
+  closeFilterSelects: () => void;
+  isBelow1280px: boolean;
+  isCommentMobileFocused: boolean;
+  isInlineDraftOpen: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+  setIsDiscardCommentOverlayVisible: (visible: boolean) => void;
+  setIsDiscardSuggestionOverlayVisible: (visible: boolean) => void;
+}
+
+export const useCommentDrawerLifecycle = ({
+  activeSuggestionDraftCard,
+  closeFilterSelects,
+  isBelow1280px,
+  isCommentMobileFocused,
+  isInlineDraftOpen,
+  isOpen,
+  onClose,
+  setIsDiscardCommentOverlayVisible,
+  setIsDiscardSuggestionOverlayVisible,
+}: UseCommentDrawerLifecycleProps) => {
+  useEscapeKey(() => {
+    if (isInlineDraftOpen) {
+      setIsDiscardCommentOverlayVisible(true);
+      return;
+    }
+
+    if (isBelow1280px && activeSuggestionDraftCard) {
+      setIsDiscardSuggestionOverlayVisible(true);
+      return;
+    }
+
+    onClose();
+  });
+
+  useEffect(() => {
+    if (!isOpen && !isInlineDraftOpen) {
+      setIsDiscardCommentOverlayVisible(false);
+      closeFilterSelects();
+    }
+  }, [
+    closeFilterSelects,
+    isInlineDraftOpen,
+    isOpen,
+    setIsDiscardCommentOverlayVisible,
+  ]);
+
+  useEffect(() => {
+    if (!activeSuggestionDraftCard) {
+      setIsDiscardSuggestionOverlayVisible(false);
+    }
+  }, [activeSuggestionDraftCard, setIsDiscardSuggestionOverlayVisible]);
+
+  useEffect(() => {
+    // Keep the canvas lift scoped to the one state that actually needs it:
+    // a focused mobile thread with the drawer sheet covering the viewport.
+    if (
+      isBelow1280px &&
+      isOpen &&
+      isCommentMobileFocused &&
+      !isInlineDraftOpen
+    ) {
+      return () => {
+        clearMobileCommentDrawerCanvasOffset();
+      };
+    }
+
+    clearMobileCommentDrawerCanvasOffset();
+    return () => {
+      clearMobileCommentDrawerCanvasOffset();
+    };
+  }, [isBelow1280px, isCommentMobileFocused, isInlineDraftOpen, isOpen]);
+};

--- a/package/components/inline-comment/use-comment-list-container.ts
+++ b/package/components/inline-comment/use-comment-list-container.ts
@@ -64,11 +64,12 @@ export const useCommentListContainer = ({
         ),
     [mountedFloatingCardIds, floatingCardMap],
   );
+  const shouldRender = isDesktopFloatingEnabled && floatingCards.length > 0;
 
   return {
     floatingCardListContainerRef,
     mountedFloatingCards,
     registerCardNode,
-    shouldRender: isDesktopFloatingEnabled && floatingCards.length > 0,
+    shouldRender,
   };
 };

--- a/package/components/inline-comment/use-floating-card-state.ts
+++ b/package/components/inline-comment/use-floating-card-state.ts
@@ -107,7 +107,8 @@ export const useFloatingCardState = (): UseFloatingCardStateResult => {
 
   const markFloatingCardInvalidated = useCallback(
     (floatingCardId: string, flag: FloatingLayoutInvalidationFlag) => {
-      getFloatingCardRuntimeState(floatingCardId).invalidationFlags |= flag;
+      const runtimeState = getFloatingCardRuntimeState(floatingCardId);
+      runtimeState.invalidationFlags |= flag;
     },
     [getFloatingCardRuntimeState],
   );
@@ -227,11 +228,13 @@ export const useFloatingCardState = (): UseFloatingCardStateResult => {
     [],
   );
 
-  const getFloatingCardLayoutInputs = useCallback(() => {
-    return orderedFloatingCardIdsRef.current.map((floatingCardId) =>
-      toFloatingCardLayoutInput(getFloatingCardRuntimeState(floatingCardId)),
-    );
-  }, [getFloatingCardRuntimeState]);
+  const getFloatingCardLayoutInputs = useCallback(
+    () =>
+      orderedFloatingCardIdsRef.current.map((floatingCardId) =>
+        toFloatingCardLayoutInput(getFloatingCardRuntimeState(floatingCardId)),
+      ),
+    [getFloatingCardRuntimeState],
+  );
 
   const resetFloatingCardState = useCallback(() => {
     floatingCardStateRef.current.clear();

--- a/package/components/inline-comment/use-floating-layout-engine.ts
+++ b/package/components/inline-comment/use-floating-layout-engine.ts
@@ -133,6 +133,10 @@ export const useFloatingLayoutEngine = ({
     new Map(),
   );
   const focusedFloatingCardIdRef = useRef<string | null>(null);
+  // DOM registry for mounted floating cards. The layout engine needs ID -> node
+  // access to measure heights and write transforms, while ResizeObserver needs
+  // node -> ID access to map height changes back to the right card.
+  // Keep both directions in sync through registerCardNode only.
   const domRegistryRef = useRef({
     cardNodes: new Map<string, HTMLDivElement>(),
     nodeToFloatingCardId: new WeakMap<Element, string>(),
@@ -613,7 +617,8 @@ export const useFloatingLayoutEngine = ({
         return;
       }
 
-      // Every floating card DOM node is registered here so layout can measure it, move it, and react to mount or unmount changes.
+      // Register the card before measuring or observing it so all layout paths
+      // use the same mounted-node source of truth.
       domRegistryRef.current.cardNodes.set(floatingCardId, node);
 
       if (floatingCardId === focusedFloatingCardId) {
@@ -677,11 +682,24 @@ export const useFloatingLayoutEngine = ({
       focusedFloatingCardId !== null &&
       previousFocusedFloatingCardId !== focusedFloatingCardId;
 
-    if (didClearFocusedThread || didTransferFocusedThread) {
+    if (didTransferFocusedThread) {
       pendingFullFocusedPassRef.current = true;
     }
 
     if (!focusedFloatingCardId) {
+      if (didClearFocusedThread) {
+        // Click-away exits focused layout. Force a full unfocused pass now so
+        // the card does not keep stale focused-stack transforms until refocus.
+        pendingFullFocusedPassRef.current = false;
+        floatingCardsRef.current.forEach((floatingCard) => {
+          markFloatingCardInvalidated(
+            floatingCard.floatingCardId,
+            FloatingLayoutInvalidationFlag.Anchor,
+          );
+        });
+        markRecomputeFromIndex(0);
+        updateLayout();
+      }
       return;
     }
 
@@ -962,6 +980,13 @@ export const useFloatingLayoutEngine = ({
     if (editorWrapperRef.current) {
       resizeObserver.observe(editorWrapperRef.current);
     }
+
+    // Ref callbacks may register cards before this effect creates the observer.
+    // Observe the current registry so consumer-driven content changes, like
+    // incoming replies, trigger the normal height-measurement path.
+    domRegistryRef.current.cardNodes.forEach((node) => {
+      resizeObserver.observe(node);
+    });
 
     return () => {
       resizeObserver.disconnect();

--- a/package/components/inline-comment/use-floating-layout-engine.ts
+++ b/package/components/inline-comment/use-floating-layout-engine.ts
@@ -820,7 +820,6 @@ export const useFloatingLayoutEngine = ({
     markRecomputeFromIndex(focusedFloatingCardIndex ?? 0);
     updateLayout();
   }, [
-    mountedFloatingCardIds,
     focusedFloatingCardId,
     floatingCardStateRef,
     getOrderedFloatingCardIndex,

--- a/package/components/inline-comment/use-floating-layout-engine.ts
+++ b/package/components/inline-comment/use-floating-layout-engine.ts
@@ -5,6 +5,7 @@ import type { Transaction } from '@tiptap/pm/state';
 import { useOnClickOutside } from 'usehooks-ts';
 import { commentDecorationPluginKey } from '../../extensions/comment/comment-decoration-plugin';
 import {
+  FLOATING_COMMENT_BOTTOM_SPACE,
   FLOATING_COMMENT_CARD_GAP,
   FloatingLayoutInvalidationFlag,
   computeFloatingCommentLayout,
@@ -46,6 +47,30 @@ const isFloatingUiInteractionTarget = (target: EventTarget | null) => {
     target.closest(
       '[data-inline-comment-actions-menu], [data-radix-popper-content-wrapper], [data-floating-ui-portal], [role="dialog"]',
     ),
+  );
+};
+
+const FLOATING_COMMENT_CONTAINER_MIN_HEIGHT_PROPERTY =
+  '--floating-comment-container-min-height';
+
+const isVerticalRangeInViewportBuffer = ({
+  top,
+  bottom,
+  viewportTop,
+  viewportBottom,
+  viewportHeight,
+}: {
+  top: number;
+  bottom: number;
+  viewportTop: number;
+  viewportBottom: number;
+  viewportHeight: number;
+}) => {
+  const viewportBuffer = viewportHeight * FLOATING_VIEWPORT_BUFFER_MULTIPLIER;
+
+  return (
+    bottom >= viewportTop - viewportBuffer &&
+    top <= viewportBottom + viewportBuffer
   );
 };
 
@@ -150,6 +175,8 @@ export const useFloatingLayoutEngine = ({
   const pendingFullFocusedPassRef = useRef(false);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const lastContainerTopRef = useRef<number | null>(null);
+  const lastContainerMinHeightElementRef = useRef<HTMLDivElement | null>(null);
+  const lastContainerMinHeightRef = useRef<number | null>(null);
   // Small counters that tell the layout loop what changed since last time.
   const layoutVersionRef = useRef({
     scroll: 0,
@@ -270,6 +297,22 @@ export const useFloatingLayoutEngine = ({
       const scrollContainerRect = scrollContainer.getBoundingClientRect();
       const floatingCardListContainerRect =
         floatingCardListContainer.getBoundingClientRect();
+      const editorWrapperRect =
+        editorWrapperRef.current?.getBoundingClientRect();
+      const editorWrapperBottom =
+        editorWrapperRect !== undefined
+          ? Math.max(
+              0,
+              editorWrapperRect.bottom - floatingCardListContainerRect.top,
+            )
+          : 0;
+
+      if (
+        lastContainerMinHeightElementRef.current !== floatingCardListContainer
+      ) {
+        lastContainerMinHeightElementRef.current = floatingCardListContainer;
+        lastContainerMinHeightRef.current = null;
+      }
 
       if (
         lastContainerTopRef.current === null ||
@@ -335,12 +378,13 @@ export const useFloatingLayoutEngine = ({
         // Read the DOM again when the card is near the viewport or changed.
         const isProjectedInViewportBuffer =
           projectedRect !== null &&
-          projectedRect.top >=
-            viewportTop -
-              viewportHeight * FLOATING_VIEWPORT_BUFFER_MULTIPLIER &&
-          projectedRect.top <=
-            viewportBottom +
-              viewportHeight * FLOATING_VIEWPORT_BUFFER_MULTIPLIER;
+          isVerticalRangeInViewportBuffer({
+            top: projectedRect.top,
+            bottom: projectedRect.top + projectedRect.height,
+            viewportTop,
+            viewportBottom,
+            viewportHeight,
+          });
         const anchorVersionChanged =
           floatingCardRuntimeState.anchorVersion !== anchorEntry.anchorVersion;
         const shouldReadRect =
@@ -378,14 +422,31 @@ export const useFloatingLayoutEngine = ({
 
         floatingCardRuntimeState.anchorVersion = anchorEntry.anchorVersion;
 
-        const nextIsGated =
+        const nextAnchorIsGated =
           floatingCardRuntimeState.anchorTop !== null &&
-          floatingCardRuntimeState.anchorTop >=
-            viewportTop -
-              viewportHeight * FLOATING_VIEWPORT_BUFFER_MULTIPLIER &&
-          floatingCardRuntimeState.anchorTop <=
-            viewportBottom +
-              viewportHeight * FLOATING_VIEWPORT_BUFFER_MULTIPLIER;
+          isVerticalRangeInViewportBuffer({
+            top: floatingCardRuntimeState.anchorTop,
+            bottom:
+              floatingCardRuntimeState.anchorTop +
+              Math.max(floatingCardRuntimeState.anchorHeight, 1),
+            viewportTop,
+            viewportBottom,
+            viewportHeight,
+          });
+        const floatingCardTop =
+          floatingCardRuntimeState.translateY ??
+          floatingCardRuntimeState.lastCommittedTranslateY;
+        const nextCardIsGated =
+          floatingCardRuntimeState.isMeasured &&
+          floatingCardTop !== null &&
+          isVerticalRangeInViewportBuffer({
+            top: floatingCardTop,
+            bottom: floatingCardTop + floatingCardRuntimeState.height,
+            viewportTop,
+            viewportBottom,
+            viewportHeight,
+          });
+        const nextIsGated = nextAnchorIsGated || nextCardIsGated;
 
         if (floatingCardRuntimeState.isInViewport !== nextIsGated) {
           const wasGated = floatingCardRuntimeState.isInViewport;
@@ -408,7 +469,10 @@ export const useFloatingLayoutEngine = ({
       layoutVersionRef.current.appliedContainerOffset =
         layoutVersionRef.current.containerOffset;
 
-      // Only mount cards inside the viewport buffer. Keeping the DOM smaller is  cheaper than rendering every card while still preserving runtime state.
+      // Only mount cards inside the viewport buffer. Keeping the DOM smaller is
+      // cheaper than rendering every card while still preserving runtime state.
+      // Tall cards stay mounted while their own measured range is near view,
+      // even after the anchor itself has scrolled out of the buffer.
       const nextMountedFloatingCardIds =
         orderedFloatingCardIdsRef.current.filter((floatingCardId) => {
           const floatingCardRuntimeState =
@@ -509,12 +573,14 @@ export const useFloatingLayoutEngine = ({
         pendingFullFocusedPassRef.current = false;
       }
 
+      let floatingCardStackBottom = 0;
+
       orderedFloatingCardIdsRef.current.forEach((floatingCardId) => {
         const floatingCardRuntimeState =
           floatingCardStateRef.current.get(floatingCardId);
         const node = domRegistryRef.current.cardNodes.get(floatingCardId);
 
-        if (!floatingCardRuntimeState || !node) {
+        if (!floatingCardRuntimeState) {
           return;
         }
 
@@ -522,6 +588,30 @@ export const useFloatingLayoutEngine = ({
           translateY: floatingCardRuntimeState.translateY,
           isVisible: floatingCardRuntimeState.lastCommittedVisible,
         };
+        const stackTranslateY =
+          placement.translateY ??
+          floatingCardRuntimeState.translateY ??
+          floatingCardRuntimeState.lastCommittedTranslateY;
+
+        if (
+          !isHidden &&
+          floatingCardRuntimeState.isMeasured &&
+          stackTranslateY !== null
+        ) {
+          const roundedStackTranslateY =
+            roundFloatingTranslateY(stackTranslateY);
+
+          if (roundedStackTranslateY !== null) {
+            floatingCardStackBottom = Math.max(
+              floatingCardStackBottom,
+              roundedStackTranslateY + floatingCardRuntimeState.height,
+            );
+          }
+        }
+
+        if (!node) {
+          return;
+        }
 
         if (layoutResult.placements.has(floatingCardId)) {
           floatingCardRuntimeState.translateY = placement.translateY;
@@ -558,6 +648,22 @@ export const useFloatingLayoutEngine = ({
           floatingCardRuntimeState.lastCommittedVisible = shouldShow;
         }
       });
+
+      const floatingCardStackExtent =
+        floatingCardStackBottom > 0
+          ? floatingCardStackBottom + FLOATING_COMMENT_BOTTOM_SPACE
+          : 0;
+      const nextContainerMinHeight = Math.ceil(
+        Math.max(editorWrapperBottom, floatingCardStackExtent),
+      );
+
+      if (lastContainerMinHeightRef.current !== nextContainerMinHeight) {
+        floatingCardListContainer.style.setProperty(
+          FLOATING_COMMENT_CONTAINER_MIN_HEIGHT_PROPERTY,
+          `${nextContainerMinHeight}px`,
+        );
+        lastContainerMinHeightRef.current = nextContainerMinHeight;
+      }
 
       clearInvalidationFlagsThroughIndex(layoutResult.stopIndex);
       layoutBoundaryRef.current.recomputeFromIndex =
@@ -796,6 +902,8 @@ export const useFloatingLayoutEngine = ({
       appliedContainerOffset: -1,
     };
     lastContainerTopRef.current = null;
+    lastContainerMinHeightElementRef.current = null;
+    lastContainerMinHeightRef.current = null;
     focusedFloatingCardRef.current = null;
     previousFocusedFloatingCardIdRef.current = null;
     pendingFullFocusedPassRef.current = false;

--- a/package/components/inline-comment/use-is-selected-content-deleted.ts
+++ b/package/components/inline-comment/use-is-selected-content-deleted.ts
@@ -7,6 +7,7 @@ export function useIsSelectedContentDeleted(
   commentId: string | undefined,
   selectedContent: string | undefined,
   commentTabId: string | undefined,
+  isSuggestion = false,
 ): boolean {
   const {
     activeCommentAnchorIds,
@@ -16,7 +17,11 @@ export function useIsSelectedContentDeleted(
   const activeTabId = useCommentStore((s) => s.activeTabId);
 
   return useMemo(() => {
-    if (!selectedContent || !commentId) {
+    if (!commentId) {
+      return false;
+    }
+
+    if (!selectedContent && !isSuggestion) {
       return false;
     }
 
@@ -40,6 +45,7 @@ export function useIsSelectedContentDeleted(
     commentId,
     commentTabId,
     hasRenderedCommentAnchor,
+    isSuggestion,
     selectedContent,
   ]);
 }

--- a/package/components/inline-comment/use-mobile-comment-navigation.ts
+++ b/package/components/inline-comment/use-mobile-comment-navigation.ts
@@ -1,0 +1,98 @@
+import { useCallback, useMemo } from 'react';
+import type { RefObject } from 'react';
+import type { IComment } from '../../extensions/comment';
+
+interface UseMobileCommentNavigationProps {
+  comments: IComment[];
+  mobileDrawerRef: RefObject<HTMLDivElement>;
+  onCommentFocus: (commentId: string, tabId?: string) => void;
+  openReplyId: string | null;
+  setOpenReplyId: (commentId: string | null) => void;
+}
+
+export const useMobileCommentNavigation = ({
+  comments,
+  mobileDrawerRef,
+  onCommentFocus,
+  openReplyId,
+  setOpenReplyId,
+}: UseMobileCommentNavigationProps) => {
+  const mobileActiveComments = useMemo(
+    () =>
+      comments
+        .filter((comment) => !comment.deleted)
+        .sort(
+          (a, b) =>
+            new Date(b.createdAt || 0).getTime() -
+            new Date(a.createdAt || 0).getTime(),
+        ),
+    [comments],
+  );
+  const mobileFocusedCommentIndex = mobileActiveComments.findIndex(
+    (comment) => comment.id === openReplyId,
+  );
+  const canGoToPreviousMobileComment = mobileFocusedCommentIndex > 0;
+  const canGoToNextMobileComment =
+    mobileFocusedCommentIndex >= 0 &&
+    mobileFocusedCommentIndex < mobileActiveComments.length - 1;
+
+  const handleViewAllComments = useCallback(() => {
+    setOpenReplyId(null);
+  }, [setOpenReplyId]);
+
+  const focusMobileComment = useCallback(
+    (commentIndex: number) => {
+      const targetComment = mobileActiveComments[commentIndex];
+
+      if (!targetComment?.id) {
+        return;
+      }
+
+      setOpenReplyId(targetComment.id);
+      onCommentFocus(targetComment.id, targetComment.tabId);
+
+      requestAnimationFrame(() => {
+        const commentElement =
+          mobileDrawerRef.current?.querySelector<HTMLElement>(
+            `[data-comment-id="${targetComment.id}"]`,
+          );
+
+        commentElement?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+        });
+      });
+    },
+    [mobileActiveComments, mobileDrawerRef, onCommentFocus, setOpenReplyId],
+  );
+
+  const handlePreviousMobileComment = useCallback(() => {
+    if (!canGoToPreviousMobileComment) {
+      return;
+    }
+
+    focusMobileComment(mobileFocusedCommentIndex - 1);
+  }, [
+    canGoToPreviousMobileComment,
+    focusMobileComment,
+    mobileFocusedCommentIndex,
+  ]);
+
+  const handleNextMobileComment = useCallback(() => {
+    if (!canGoToNextMobileComment) {
+      return;
+    }
+
+    focusMobileComment(mobileFocusedCommentIndex + 1);
+  }, [canGoToNextMobileComment, focusMobileComment, mobileFocusedCommentIndex]);
+
+  return {
+    canGoToNextMobileComment,
+    canGoToPreviousMobileComment,
+    handleNextMobileComment,
+    handlePreviousMobileComment,
+    handleViewAllComments,
+    mobileActiveCommentsCount: mobileActiveComments.length,
+    mobileFocusedCommentIndex,
+  };
+};

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -269,6 +269,7 @@ const DdocEditor = forwardRef(
       deleteTab,
       commentAnchorsRef,
       draftAnchorsRef,
+      storeApiRef,
     } = useDdocEditor({
       documentStyling,
       ipfsImageFetchFn,
@@ -1202,6 +1203,7 @@ const DdocEditor = forwardRef(
               setCommentDrawerOpen={setCommentDrawerOpen}
               commentAnchorsRef={commentAnchorsRef}
               draftAnchorsRef={draftAnchorsRef}
+              storeApiRef={storeApiRef}
               initialCommentAnchors={initialCommentAnchors}
             >
               {renderComp()}

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -58,6 +58,7 @@ const DdocEditor = forwardRef(
   (
     {
       isPreviewMode = false,
+      viewerMode,
       initialContent,
       collaboration,
       username,
@@ -274,6 +275,7 @@ const DdocEditor = forwardRef(
       enableIndexeddbSync,
       ddocId,
       isPreviewMode,
+      viewerMode,
       initialContent,
       collaboration,
       walletAddress,
@@ -313,6 +315,7 @@ const DdocEditor = forwardRef(
       isAIAgentEnabled,
       isDDocOwner,
       tabConfig,
+      onNewComment,
       ...rest,
     });
     const currentTabName = useMemo(
@@ -902,6 +905,9 @@ const DdocEditor = forwardRef(
                                 <div>
                                   <EditingProvider
                                     isPreviewMode={isPreviewMode}
+                                    isSuggestionMode={
+                                      isPreviewMode && viewerMode === 'suggest'
+                                    }
                                     isCollaboratorsDoc={
                                       collaboration?.enabled === true &&
                                       !collaboration.connection.isOwner

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -1028,7 +1028,10 @@ const DdocEditor = forwardRef(
                             editorWrapperRef={editorWrapperRef}
                             scrollContainerRef={editorScrollContainerRef}
                             tabName={currentTabName}
-                            isHidden={Boolean(commentDrawerOpen)}
+                            isHidden={
+                              Boolean(commentDrawerOpen) ||
+                              Boolean(disableInlineComment)
+                            }
                             isCollaborationEnabled={collaboration?.enabled}
                           />
                         </div>

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -268,6 +268,7 @@ const DdocEditor = forwardRef(
       orderTab,
       deleteTab,
       commentAnchorsRef,
+      draftAnchorsRef,
     } = useDdocEditor({
       documentStyling,
       ipfsImageFetchFn,
@@ -1200,6 +1201,7 @@ const DdocEditor = forwardRef(
               onComment={onComment}
               setCommentDrawerOpen={setCommentDrawerOpen}
               commentAnchorsRef={commentAnchorsRef}
+              draftAnchorsRef={draftAnchorsRef}
               initialCommentAnchors={initialCommentAnchors}
             >
               {renderComp()}

--- a/package/extensions/ai-writer/ai-writer-node-view.tsx
+++ b/package/extensions/ai-writer/ai-writer-node-view.tsx
@@ -25,6 +25,7 @@ import {
 } from '@fileverse/ui';
 import styles from './ai-writer-node-view.module.scss';
 import { useResponsive } from '../../utils/responsive';
+import { useEditingContext } from '../../hooks/use-editing-context';
 import { TextSelection } from 'prosemirror-state';
 import { SuperchargedTableExtensions } from '../supercharged-table/supercharged-table-kit';
 import { ModelOption, WindowWithModelContext, ModelService } from './types';
@@ -54,7 +55,8 @@ export const AIWriterNodeView = memo(
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const selectContentRef = useRef<HTMLDivElement>(null);
-    const isPreviewMode = !parentEditor.isEditable;
+    const { isSuggestionMode } = useEditingContext();
+    const isPreviewMode = !parentEditor.isEditable || !!isSuggestionMode;
     // Add platform detection
     const { isWindows } = useResponsive();
     const shortcutKey = isWindows ? 'Ctrl' : 'Cmd';

--- a/package/extensions/code-block/components/code-block-node-view.tsx
+++ b/package/extensions/code-block/components/code-block-node-view.tsx
@@ -15,6 +15,7 @@ import {
 import { NodeViewWrapper, NodeViewContent, NodeViewProps } from '@tiptap/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useResponsive } from '../../../utils/responsive';
+import { useEditingContext } from '../../../hooks/use-editing-context';
 
 const LANGUAGE_GROUPS = [
   {
@@ -96,9 +97,10 @@ export default function CodeBlockNodeView({
 }: NodeViewProps) {
   const codeRef = useRef<HTMLDivElement>(null);
   const [copyIcon, setCopyIcon] = useState<'Copy' | 'Check'>('Copy');
+  const { isSuggestionMode } = useEditingContext();
   // Read attributes with sensible defaults
   const language = node.attrs.language || 'plaintext';
-  const isPreviewMode = !editor.isEditable;
+  const isPreviewMode = !editor.isEditable || !!isSuggestionMode;
   const lineNumbers = node.attrs.lineNumbers && !isPreviewMode;
   const wordWrap = node.attrs.wordWrap && !isPreviewMode;
   const tabSize = node.attrs.tabSize ?? 2;

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -21,6 +21,7 @@ import {
   relativePositionToAbsolutePosition,
 } from '@tiptap/y-tiptap';
 import * as Y from 'yjs';
+import { SuggestionType } from '../../types';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -32,6 +33,10 @@ export interface CommentAnchor {
   anchorTo: Y.RelativePosition;
   resolved: boolean;
   deleted: boolean;
+  isSuggestion?: boolean;
+  suggestionType?: SuggestionType;
+  originalContent?: string;
+  suggestedContent?: string;
 }
 
 interface CommentDecorationPluginState {
@@ -613,4 +618,62 @@ export function getCommentAnchorRange(
   }
 
   return resolveCommentAnchorRangeInState(anchor, editor.state);
+}
+
+/**
+ * Apply the accepted suggestion's change to the document.
+ * Called by the store's acceptSuggestion action before resolving on-chain.
+ * Returns false if the anchor can't be resolved or the suggestion type is unknown.
+ */
+export function applyAcceptedSuggestion(
+  editor: Editor,
+  anchor: CommentAnchor,
+): boolean {
+  if (!anchor.isSuggestion) return false;
+
+  const state = editor.state;
+  const syncState = ySyncPluginKey.getState(state);
+  if (!syncState?.binding) return false;
+
+  const { doc, type, binding } = syncState;
+
+  try {
+    const from = relativePositionToAbsolutePosition(
+      doc,
+      type,
+      anchor.anchorFrom,
+      binding.mapping,
+    );
+    const to = relativePositionToAbsolutePosition(
+      doc,
+      type,
+      anchor.anchorTo,
+      binding.mapping,
+    );
+
+    if (from === null || to === null) return false;
+    if (from < 0 || to > state.doc.content.size) return false;
+
+    const { suggestionType, suggestedContent } = anchor;
+    const { tr } = state;
+
+    if (suggestionType === 'add') {
+      if (!suggestedContent) return false;
+      tr.insertText(suggestedContent, from);
+    } else if (suggestionType === 'delete') {
+      if (from >= to) return false;
+      tr.delete(from, to);
+    } else if (suggestionType === 'replace') {
+      if (from >= to || !suggestedContent) return false;
+      // insertText with a range replaces from..to with the new text
+      tr.insertText(suggestedContent, from, to);
+    } else {
+      return false;
+    }
+
+    editor.view.dispatch(tr);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -805,34 +805,29 @@ export function applyAcceptedSuggestion(
 
     const { suggestionType, suggestedContent } = anchor;
 
-    // Route through TipTap's command pipeline (chain → command → run) instead
-    // of calling editor.view.dispatch(tr) directly. The pipeline guarantees
-    // the transaction emits the editor's `update` event, which the consumer's
-    // y-prosemirror sync + onChange handler depend on for autosave / publish-
-    // dirty detection. A direct view.dispatch can skip that path in some
-    // setups, leaving the doc visibly changed but unpersisted.
-    return editor
-      .chain()
-      .command(({ tr }) => {
-        if (suggestionType === 'add') {
-          if (!suggestedContent) return false;
-          tr.insertText(suggestedContent, from);
-          return true;
-        }
-        if (suggestionType === 'delete') {
-          if (from >= to) return false;
-          tr.delete(from, to);
-          return true;
-        }
-        if (suggestionType === 'replace') {
-          if (from >= to || !suggestedContent) return false;
-          // insertText with a range replaces from..to with the new text
-          tr.insertText(suggestedContent, from, to);
-          return true;
-        }
-        return false;
-      })
-      .run();
+    // Use TipTap's high-level commands (insertContentAt / deleteRange) — same
+    // pattern used elsewhere in the package (slash commands, dBlock, etc.).
+    // These wrap the y-prosemirror sync correctly so the doc change reaches
+    // Y.Doc → onChange → IndexedDB. Raw tr.insertText / tr.delete inside a
+    // chain().command() does NOT propagate to Y.Doc reliably, leaving the
+    // doc visibly changed but unpersisted.
+    if (suggestionType === 'add') {
+      if (!suggestedContent) return false;
+      return editor.commands.insertContentAt(from, suggestedContent);
+    }
+    if (suggestionType === 'delete') {
+      if (from >= to) return false;
+      return editor.commands.deleteRange({ from, to });
+    }
+    if (suggestionType === 'replace') {
+      if (from >= to || !suggestedContent) return false;
+      return editor
+        .chain()
+        .deleteRange({ from, to })
+        .insertContentAt(from, suggestedContent)
+        .run();
+    }
+    return false;
   } catch {
     return false;
   }

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -804,24 +804,35 @@ export function applyAcceptedSuggestion(
     if (from < 0 || to > state.doc.content.size) return false;
 
     const { suggestionType, suggestedContent } = anchor;
-    const { tr } = state;
 
-    if (suggestionType === 'add') {
-      if (!suggestedContent) return false;
-      tr.insertText(suggestedContent, from);
-    } else if (suggestionType === 'delete') {
-      if (from >= to) return false;
-      tr.delete(from, to);
-    } else if (suggestionType === 'replace') {
-      if (from >= to || !suggestedContent) return false;
-      // insertText with a range replaces from..to with the new text
-      tr.insertText(suggestedContent, from, to);
-    } else {
-      return false;
-    }
-
-    editor.view.dispatch(tr);
-    return true;
+    // Route through TipTap's command pipeline (chain → command → run) instead
+    // of calling editor.view.dispatch(tr) directly. The pipeline guarantees
+    // the transaction emits the editor's `update` event, which the consumer's
+    // y-prosemirror sync + onChange handler depend on for autosave / publish-
+    // dirty detection. A direct view.dispatch can skip that path in some
+    // setups, leaving the doc visibly changed but unpersisted.
+    return editor
+      .chain()
+      .command(({ tr }) => {
+        if (suggestionType === 'add') {
+          if (!suggestedContent) return false;
+          tr.insertText(suggestedContent, from);
+          return true;
+        }
+        if (suggestionType === 'delete') {
+          if (from >= to) return false;
+          tr.delete(from, to);
+          return true;
+        }
+        if (suggestionType === 'replace') {
+          if (from >= to || !suggestedContent) return false;
+          // insertText with a range replaces from..to with the new text
+          tr.insertText(suggestedContent, from, to);
+          return true;
+        }
+        return false;
+      })
+      .run();
   } catch {
     return false;
   }

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -642,6 +642,31 @@ export function createCommentAnchorFromEditor(
   return createCommentAnchorFromRangeInState(editor.state, from, to);
 }
 
+/**
+ * Create a point anchor (anchorFrom === anchorTo) at a single doc position.
+ * Used by the suggestion-mode draft flow when the viewer places a cursor
+ * without selecting text — createCommentAnchorFromEditor rejects from >= to
+ * since an empty range is invalid for regular comments.
+ */
+export function createCommentAnchorPointFromEditor(
+  editor: Editor,
+  pos: number,
+): CommentAnchorRelativeRange | null {
+  const syncState = ySyncPluginKey.getState(editor.state);
+  if (!syncState?.binding) return null;
+  const { type, binding } = syncState;
+  try {
+    const relPos = absolutePositionToRelativePosition(
+      pos,
+      type,
+      binding.mapping,
+    );
+    return { anchorFrom: relPos, anchorTo: relPos };
+  } catch {
+    return null;
+  }
+}
+
 export function createCommentAnchorFromSelection(
   editor: Editor,
 ): CommentAnchorRelativeRange | null {

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -113,6 +113,33 @@ export function resolveCommentAnchorRangeInState(
   }
 }
 
+/**
+ * Resolve anchorFrom to a single absolute position.
+ * Used for 'add' suggestion anchors where anchorFrom === anchorTo (cursor,
+ * no initial selection) — resolveCommentAnchorRangeInState rejects from >= to,
+ * so we need a separate path that allows a point position.
+ */
+export function resolveCommentAnchorPointInState(
+  anchor: Pick<CommentAnchor, 'anchorFrom'>,
+  state: EditorState,
+): number | null {
+  const syncState = ySyncPluginKey.getState(state);
+  if (!syncState?.binding) return null;
+  const { doc, type, binding } = syncState;
+  try {
+    const pos = relativePositionToAbsolutePosition(
+      doc,
+      type,
+      anchor.anchorFrom,
+      binding.mapping,
+    );
+    if (pos === null || pos < 0 || pos > state.doc.content.size) return null;
+    return pos;
+  } catch {
+    return null;
+  }
+}
+
 function resolveCommentAnchorRangeFromRenderedDecorations(
   commentId: string,
   state: EditorState,
@@ -402,6 +429,15 @@ export function analyzeCommentAnchorTransactionChanges(
 // ---------------------------------------------------------------------------
 // Build decorations from anchors
 // ---------------------------------------------------------------------------
+
+function createSuggestionWidget(text: string, commentId: string): HTMLElement {
+  const span = document.createElement('span');
+  span.className = 'suggestion-add';
+  span.textContent = text;
+  span.dataset.suggestionId = commentId;
+  return span;
+}
+
 
 function buildDecorations(
   anchors: CommentAnchor[],

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -252,6 +252,16 @@ function getImpactingChangedRanges(
   );
 }
 
+// Mark/attribute-only steps have empty StepMaps. Tiptap still reports their
+// from/to as changed ranges, but they do not move or delete anchored text.
+function isPositionPreservingTransform(transform: Transform) {
+  return transform.mapping.maps.every((stepMap) => {
+    const ranges = (stepMap as unknown as { ranges?: readonly number[] })
+      .ranges;
+    return !ranges || ranges.length === 0;
+  });
+}
+
 function doChangedRangesCoverWholeAnchor(
   changedRanges: ChangedRange[],
   anchorRange: CommentAnchorRange,
@@ -321,15 +331,16 @@ function mapAnchorRangeThroughTransform(
  * whether each anchor remains unchanged, gets edited, or is deleted.
  *
  * Classification rules (in order):
- * 1. Skip deleted or resolved anchors → 'unchanged'
- * 2. If anchor has no old position → 'unchanged'
- * 3. If no changed ranges touch the anchor → 'unchanged'
- * 4. If any changed range fully covers the anchor → 'deleted' (full-span replacement)
- * 5. If combined changed ranges fully cover the anchor → 'deleted' (multi-step removal)
- * 6. If anchor maps through transform → check if position or content changed:
+ * 1. If the transform preserves positions → 'unchanged'
+ * 2. Skip deleted or resolved anchors → 'unchanged'
+ * 3. If anchor has no old position → 'unchanged'
+ * 4. If no changed ranges touch the anchor → 'unchanged'
+ * 5. If any changed range fully covers the anchor → 'deleted' (full-span replacement)
+ * 6. If combined changed ranges fully cover the anchor → 'deleted' (multi-step removal)
+ * 7. If anchor maps through transform → check if position or content changed:
  *    a. If both unchanged → 'unchanged'
  *    b. Otherwise → 'edited' (return new position and relative anchor)
- * 7. If mapping fails → 'deleted'
+ * 8. If mapping fails → 'deleted'
  */
 export function analyzeCommentAnchorTransactionChanges(
   anchors: CommentAnchor[],
@@ -337,6 +348,10 @@ export function analyzeCommentAnchorTransactionChanges(
   newState: EditorState,
   transform: Transform,
 ): CommentAnchorTransactionChange[] {
+  if (isPositionPreservingTransform(transform)) {
+    return anchors.map((anchor) => ({ id: anchor.id, type: 'unchanged' }));
+  }
+
   const changedRanges = getChangedRanges(transform);
 
   if (changedRanges.length === 0) {
@@ -514,6 +529,18 @@ function buildDecorations(
     // follows — suggestions don't get the inline-comment background.
     if (anchor.isSuggestion) {
       const { suggestionType, suggestedContent } = anchor;
+
+      // Link: purple text over the original selected range.
+      if (suggestionType === 'link' && range.from < range.to) {
+        decorations.push(
+          Decoration.inline(range.from, range.to, {
+            class: 'suggestion-link',
+            'data-suggestion-id': anchor.id,
+            'data-comment-id': anchor.id,
+            'data-active': isActive ? 'true' : 'false',
+          }),
+        );
+      }
 
       // Delete / Replace: strikethrough on the original text range.
       // Include both data-suggestion-id (for draft anchor lookup) and
@@ -842,6 +869,15 @@ export function applyAcceptedSuggestion(
         .focus()
         .deleteRange({ from, to })
         .insertContentAt(from, textNode(suggestedContent))
+        .run();
+    }
+    if (suggestionType === 'link') {
+      if (from >= to || !suggestedContent) return false;
+      return editor
+        .chain()
+        .focus()
+        .setTextSelection({ from, to })
+        .setLink({ href: suggestedContent })
         .run();
     }
     return false;

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -460,10 +460,15 @@ function buildDecorations(
   const decorations: Decoration[] = [];
 
   for (const anchor of anchors) {
-    // Skip resolved and deleted anchors; they have no visual representation.
-    if (anchor.deleted || anchor.resolved) {
-      continue;
-    }
+    // Skip deleted anchors entirely.
+    if (anchor.deleted) continue;
+    // Skip resolved anchors. For regular comments this is an explicit resolve.
+    // For suggestions, `resolved: true` arrives only via Accept — at which
+    // point the doc already contains the accepted text (applyAcceptedSuggestion
+    // dispatched the edit). Rendering the strikethrough/widget against the
+    // post-accept doc would put the decoration over the wrong range, so drop
+    // it everywhere.
+    if (anchor.resolved) continue;
 
     // 'add' suggestions: cursor-based, anchorFrom === anchorTo.
     // resolveCommentAnchorRangeInState rejects from >= to, so use point

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -168,6 +168,23 @@ function resolveCommentAnchorRangeFromRenderedDecorations(
   return { from, to };
 }
 
+function resolveCommentAnchorPointFromRenderedDecorations(
+  commentId: string,
+  state: EditorState,
+): number | null {
+  const pluginState = commentDecorationPluginKey.getState(state);
+  const matchingDecorations =
+    pluginState?.decorations.find(undefined, undefined, (spec) => {
+      return spec?.commentId === commentId;
+    }) ?? [];
+
+  const pointDecoration = matchingDecorations.find(
+    (decoration) => decoration.from === decoration.to,
+  );
+
+  return pointDecoration?.from ?? null;
+}
+
 export function resolveCommentAnchorRangeForAnalysis(
   anchor: Pick<CommentAnchor, 'id' | 'anchorFrom' | 'anchorTo'>,
   state: EditorState,
@@ -179,6 +196,18 @@ export function resolveCommentAnchorRangeForAnalysis(
     // user actually saw highlighted before the edit.
     resolveCommentAnchorRangeFromRenderedDecorations(anchor.id, state) ??
     resolveCommentAnchorRangeInState(anchor, state)
+  );
+}
+
+export function resolveCommentAnchorPointForAnalysis(
+  anchor: Pick<CommentAnchor, 'id' | 'anchorFrom'>,
+  state: EditorState,
+): number | null {
+  return (
+    // Match range analysis: use the rendered pre-transaction widget first,
+    // because Yjs relative positions can resolve through live mappings.
+    resolveCommentAnchorPointFromRenderedDecorations(anchor.id, state) ??
+    resolveCommentAnchorPointInState(anchor, state)
   );
 }
 
@@ -303,6 +332,20 @@ function doChangedRangesCoverWholeAnchor(
   return coveredUntil >= anchorRange.to;
 }
 
+function doesChangedRangeDeletePointAnchor(
+  changedRange: ChangedRange,
+  point: number,
+) {
+  // Add suggestions are point anchors. If existing content is deleted across
+  // either side of that point, the insertion location no longer belongs to the
+  // original text context and should not reattach to neighboring content.
+  return (
+    changedRange.oldRange.to > changedRange.oldRange.from &&
+    changedRange.oldRange.from <= point &&
+    changedRange.oldRange.to >= point
+  );
+}
+
 function mapAnchorRangeThroughTransform(
   range: CommentAnchorRange,
   transform: Transform,
@@ -362,6 +405,20 @@ export function analyzeCommentAnchorTransactionChanges(
     // Skip anchors marked as deleted or resolved.
     if (anchor.deleted || anchor.resolved) {
       return { id: anchor.id, type: 'unchanged' };
+    }
+
+    if (anchor.isSuggestion && anchor.suggestionType === 'add') {
+      const oldPoint = resolveCommentAnchorPointForAnalysis(anchor, oldState);
+
+      if (oldPoint === null) {
+        return { id: anchor.id, type: 'unchanged' };
+      }
+
+      return changedRanges.some((changedRange) =>
+        doesChangedRangeDeletePointAnchor(changedRange, oldPoint),
+      )
+        ? { id: anchor.id, type: 'deleted' }
+        : { id: anchor.id, type: 'unchanged' };
     }
 
     // Resolve the anchor's old absolute range from pre-transaction state.
@@ -507,6 +564,9 @@ function buildDecorations(
           insertPoint,
           createSuggestionWidget(anchor.suggestedContent, anchor.id, isActive),
           {
+            commentId: anchor.id,
+            active: isActive,
+            suggestion: true,
             side: -1,
             key: `suggestion-insert-${anchor.id}-${anchor.suggestedContent}-${
               isActive ? 'active' : 'inactive'
@@ -533,12 +593,17 @@ function buildDecorations(
       // Link: purple text over the original selected range.
       if (suggestionType === 'link' && range.from < range.to) {
         decorations.push(
-          Decoration.inline(range.from, range.to, {
-            class: 'suggestion-link',
-            'data-suggestion-id': anchor.id,
-            'data-comment-id': anchor.id,
-            'data-active': isActive ? 'true' : 'false',
-          }),
+          Decoration.inline(
+            range.from,
+            range.to,
+            {
+              class: 'suggestion-link',
+              'data-suggestion-id': anchor.id,
+              'data-comment-id': anchor.id,
+              'data-active': isActive ? 'true' : 'false',
+            },
+            { commentId: anchor.id, active: isActive, suggestion: true },
+          ),
         );
       }
 
@@ -550,12 +615,17 @@ function buildDecorations(
         range.from < range.to
       ) {
         decorations.push(
-          Decoration.inline(range.from, range.to, {
-            class: 'suggestion-delete',
-            'data-suggestion-id': anchor.id,
-            'data-comment-id': anchor.id,
-            'data-active': isActive ? 'true' : 'false',
-          }),
+          Decoration.inline(
+            range.from,
+            range.to,
+            {
+              class: 'suggestion-delete',
+              'data-suggestion-id': anchor.id,
+              'data-comment-id': anchor.id,
+              'data-active': isActive ? 'true' : 'false',
+            },
+            { commentId: anchor.id, active: isActive, suggestion: true },
+          ),
         );
       }
 
@@ -568,6 +638,9 @@ function buildDecorations(
             range.to,
             createSuggestionWidget(suggestedContent, anchor.id, isActive),
             {
+              commentId: anchor.id,
+              active: isActive,
+              suggestion: true,
               side: -1,
               key: `suggestion-insert-${anchor.id}-${suggestedContent}-${
                 isActive ? 'active' : 'inactive'

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -430,7 +430,11 @@ export function analyzeCommentAnchorTransactionChanges(
 // Build decorations from anchors
 // ---------------------------------------------------------------------------
 
-function createSuggestionWidget(text: string, commentId: string): HTMLElement {
+function createSuggestionWidget(
+  text: string,
+  commentId: string,
+  isActive: boolean,
+): HTMLElement {
   const span = document.createElement('span');
   span.className = 'suggestion-add';
   span.textContent = text;
@@ -438,9 +442,9 @@ function createSuggestionWidget(text: string, commentId: string): HTMLElement {
   // suggestion-draft anchor (before submit) or a thread anchor (after submit).
   span.dataset.suggestionId = commentId;
   span.dataset.commentId = commentId;
+  span.dataset.active = isActive ? 'true' : 'false';
   return span;
 }
-
 
 function buildDecorations(
   anchors: CommentAnchor[],
@@ -470,6 +474,8 @@ function buildDecorations(
     // it everywhere.
     if (anchor.resolved) continue;
 
+    const isActive = anchor.id === activeCommentId;
+
     // 'add' suggestions: cursor-based, anchorFrom === anchorTo.
     // resolveCommentAnchorRangeInState rejects from >= to, so use point
     // resolution and render a single widget. side: -1 positions the widget
@@ -484,10 +490,12 @@ function buildDecorations(
       decorations.push(
         Decoration.widget(
           insertPoint,
-          createSuggestionWidget(anchor.suggestedContent, anchor.id),
+          createSuggestionWidget(anchor.suggestedContent, anchor.id, isActive),
           {
             side: -1,
-            key: `suggestion-insert-${anchor.id}-${anchor.suggestedContent}`,
+            key: `suggestion-insert-${anchor.id}-${anchor.suggestedContent}-${
+              isActive ? 'active' : 'inactive'
+            }`,
             destroy: (node) => (node as HTMLElement).remove(),
           },
         ),
@@ -519,6 +527,7 @@ function buildDecorations(
             class: 'suggestion-delete',
             'data-suggestion-id': anchor.id,
             'data-comment-id': anchor.id,
+            'data-active': isActive ? 'true' : 'false',
           }),
         );
       }
@@ -530,10 +539,12 @@ function buildDecorations(
         decorations.push(
           Decoration.widget(
             range.to,
-            createSuggestionWidget(suggestedContent, anchor.id),
+            createSuggestionWidget(suggestedContent, anchor.id, isActive),
             {
               side: -1,
-              key: `suggestion-insert-${anchor.id}-${suggestedContent}`,
+              key: `suggestion-insert-${anchor.id}-${suggestedContent}-${
+                isActive ? 'active' : 'inactive'
+              }`,
               destroy: (node) => (node as HTMLElement).remove(),
             },
           ),
@@ -546,8 +557,6 @@ function buildDecorations(
     // Decoration state does not inherit the active-thread class that the mark
     // DOM toggles in editable mode, so mirror activeCommentId here to keep
     // preview and editable highlights visually aligned.
-    const isActive = anchor.id === activeCommentId;
-
     // Create an inline decoration at the anchor's current range.
     // The CSS class triggers visual styling; commentId enables click-to-activate-thread.
     decorations.push(

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -434,7 +434,10 @@ function createSuggestionWidget(text: string, commentId: string): HTMLElement {
   const span = document.createElement('span');
   span.className = 'suggestion-add';
   span.textContent = text;
+  // Both attributes so the layout engine can locate this widget as either a
+  // suggestion-draft anchor (before submit) or a thread anchor (after submit).
   span.dataset.suggestionId = commentId;
+  span.dataset.commentId = commentId;
   return span;
 }
 
@@ -467,6 +470,8 @@ function buildDecorations(
     // resolution and render a single widget. side: -1 positions the widget
     // visually before the caret at the same document position — gives the
     // Google-Docs-style "cursor advances through the proposed text" feel.
+    // Key includes the content so PM redraws when the draft's suggestedContent
+    // changes (typing / backspace during an Add draft).
     if (anchor.isSuggestion && anchor.suggestionType === 'add') {
       if (!anchor.suggestedContent) continue;
       const insertPoint = resolveCommentAnchorPointInState(anchor, state);
@@ -477,7 +482,7 @@ function buildDecorations(
           createSuggestionWidget(anchor.suggestedContent, anchor.id),
           {
             side: -1,
-            key: `suggestion-insert-${anchor.id}`,
+            key: `suggestion-insert-${anchor.id}-${anchor.suggestedContent}`,
             destroy: (node) => (node as HTMLElement).remove(),
           },
         ),
@@ -497,6 +502,9 @@ function buildDecorations(
     if (anchor.isSuggestion) {
       const { suggestionType, suggestedContent } = anchor;
 
+      // Delete / Replace: strikethrough on the original text range.
+      // Include both data-suggestion-id (for draft anchor lookup) and
+      // data-comment-id (for submitted thread anchor lookup).
       if (
         (suggestionType === 'delete' || suggestionType === 'replace') &&
         range.from < range.to
@@ -505,10 +513,14 @@ function buildDecorations(
           Decoration.inline(range.from, range.to, {
             class: 'suggestion-delete',
             'data-suggestion-id': anchor.id,
+            'data-comment-id': anchor.id,
           }),
         );
       }
 
+      // Replace: widget showing the proposed content after the struck-through range.
+      // Key includes the content so PM redraws when the draft's suggestedContent
+      // changes (typing / backspace during a Replace draft).
       if (suggestionType === 'replace' && suggestedContent) {
         decorations.push(
           Decoration.widget(
@@ -516,7 +528,7 @@ function buildDecorations(
             createSuggestionWidget(suggestedContent, anchor.id),
             {
               side: -1,
-              key: `suggestion-insert-${anchor.id}`,
+              key: `suggestion-insert-${anchor.id}-${suggestedContent}`,
               destroy: (node) => (node as HTMLElement).remove(),
             },
           ),
@@ -705,6 +717,19 @@ export function getCommentAtPosition(
 
   for (const anchor of anchors) {
     if (anchor.deleted) {
+      continue;
+    }
+
+    // Add suggestions are point-anchored (anchorFrom === anchorTo); range
+    // resolution rejects them. Match if the cursor sits at the insert point
+    // or anywhere inside the widget's proposed content length.
+    if (anchor.isSuggestion && anchor.suggestionType === 'add') {
+      const point = resolveCommentAnchorPointInState(anchor, editor.state);
+      if (point === null) continue;
+      const widgetEnd = point + (anchor.suggestedContent?.length ?? 0);
+      if (pos >= point && pos <= widgetEnd) {
+        return anchor;
+      }
       continue;
     }
 

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -462,9 +462,67 @@ function buildDecorations(
       continue;
     }
 
+    // 'add' suggestions: cursor-based, anchorFrom === anchorTo.
+    // resolveCommentAnchorRangeInState rejects from >= to, so use point
+    // resolution and render a single widget. side: -1 positions the widget
+    // visually before the caret at the same document position — gives the
+    // Google-Docs-style "cursor advances through the proposed text" feel.
+    if (anchor.isSuggestion && anchor.suggestionType === 'add') {
+      if (!anchor.suggestedContent) continue;
+      const insertPoint = resolveCommentAnchorPointInState(anchor, state);
+      if (insertPoint === null) continue;
+      decorations.push(
+        Decoration.widget(
+          insertPoint,
+          createSuggestionWidget(anchor.suggestedContent, anchor.id),
+          {
+            side: -1,
+            key: `suggestion-insert-${anchor.id}`,
+            destroy: (node) => (node as HTMLElement).remove(),
+          },
+        ),
+      );
+      continue;
+    }
+
     const range = resolveCommentAnchorRangeInState(anchor, state);
 
     if (!range) {
+      continue;
+    }
+
+    // Suggestion branch: render strikethrough (Delete/Replace) and/or widget
+    // (Replace's proposed text). Skip the regular comment decoration that
+    // follows — suggestions don't get the inline-comment background.
+    if (anchor.isSuggestion) {
+      const { suggestionType, suggestedContent } = anchor;
+
+      if (
+        (suggestionType === 'delete' || suggestionType === 'replace') &&
+        range.from < range.to
+      ) {
+        decorations.push(
+          Decoration.inline(range.from, range.to, {
+            class: 'suggestion-delete',
+            'data-suggestion-id': anchor.id,
+          }),
+        );
+      }
+
+      if (suggestionType === 'replace' && suggestedContent) {
+        decorations.push(
+          Decoration.widget(
+            range.to,
+            createSuggestionWidget(suggestedContent, anchor.id),
+            {
+              side: -1,
+              key: `suggestion-insert-${anchor.id}`,
+              destroy: (node) => (node as HTMLElement).remove(),
+            },
+          ),
+        );
+      }
+
       continue;
     }
 

--- a/package/extensions/comment/comment-decoration-plugin.ts
+++ b/package/extensions/comment/comment-decoration-plugin.ts
@@ -805,26 +805,34 @@ export function applyAcceptedSuggestion(
 
     const { suggestionType, suggestedContent } = anchor;
 
-    // Use TipTap's high-level commands (insertContentAt / deleteRange) — same
-    // pattern used elsewhere in the package (slash commands, dBlock, etc.).
-    // These wrap the y-prosemirror sync correctly so the doc change reaches
-    // Y.Doc → onChange → IndexedDB. Raw tr.insertText / tr.delete inside a
-    // chain().command() does NOT propagate to Y.Doc reliably, leaving the
-    // doc visibly changed but unpersisted.
+    // Insert as an explicit text node (NOT a string). When passed a string,
+    // TipTap parses it as HTML via DOMParser, wrapping in <p>. Inserting a
+    // <p> mid-paragraph causes ProseMirror to silently no-op the step — the
+    // command returns true but tr.docChanged stays false, so y-prosemirror
+    // never syncs to Y.Doc and the consumer's onChange never fires.
+    // Passing { type: 'text', text } skips parsing and produces a real
+    // ReplaceStep that y-prosemirror picks up.
+    const textNode = (text: string) => ({ type: 'text', text });
+
     if (suggestionType === 'add') {
       if (!suggestedContent) return false;
-      return editor.commands.insertContentAt(from, suggestedContent);
+      return editor
+        .chain()
+        .focus()
+        .insertContentAt(from, textNode(suggestedContent))
+        .run();
     }
     if (suggestionType === 'delete') {
       if (from >= to) return false;
-      return editor.commands.deleteRange({ from, to });
+      return editor.chain().focus().deleteRange({ from, to }).run();
     }
     if (suggestionType === 'replace') {
       if (from >= to || !suggestedContent) return false;
       return editor
         .chain()
+        .focus()
         .deleteRange({ from, to })
-        .insertContentAt(from, suggestedContent)
+        .insertContentAt(from, textNode(suggestedContent))
         .run();
     }
     return false;

--- a/package/extensions/comment/comment.ts
+++ b/package/extensions/comment/comment.ts
@@ -215,6 +215,21 @@ export const getCommentMarkRange = (
   return { from, to };
 };
 
+// TipTap's `editor.view` proxy throws when accessed before mount (the proxy
+// itself is truthy, so `?.view?.dom` doesn't help). The active-class sync
+// commands fire from store actions that may run during mount races; swallow
+// the throw and treat it as "DOM not ready yet, nothing to sync".
+const getEditorDomSafely = (
+  editor: { view?: { dom?: unknown } } | null | undefined,
+): HTMLElement | undefined => {
+  if (!editor) return undefined;
+  try {
+    return editor.view?.dom as HTMLElement | undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const getCommentNodesById = (editorDom: HTMLElement, commentId: string) => {
   const safeId =
     typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
@@ -628,7 +643,7 @@ export const CommentExtension = Mark.create<CommentOptions, CommentStorage>({
         this.storage.activeCommentId = commentId;
         // Update UI classes in-place so "active comment" does not create doc updates.
         syncActiveCommentClassInDOM(
-          this.editor?.view?.dom as HTMLElement | undefined,
+          getEditorDomSafely(this.editor),
           previousActiveCommentId,
           commentId,
         );
@@ -639,7 +654,7 @@ export const CommentExtension = Mark.create<CommentOptions, CommentStorage>({
         this.storage.activeCommentId = null;
         // Reset active styling without touching persisted mark attributes.
         syncActiveCommentClassInDOM(
-          this.editor?.view?.dom as HTMLElement | undefined,
+          getEditorDomSafely(this.editor),
           previousActiveCommentId,
           null,
         );

--- a/package/extensions/comment/comment.ts
+++ b/package/extensions/comment/comment.ts
@@ -221,8 +221,15 @@ const getCommentNodesById = (editorDom: HTMLElement, commentId: string) => {
       ? CSS.escape(commentId)
       : commentId.replace(/"/g, '\\"');
 
+  // Exclude suggestion decorations: they share `data-comment-id` so the
+  // layout engine can locate them after submit, but applying the
+  // comment-active styling here would (a) add a green bg that masks the
+  // suggestion's red strikethrough / green widget text and (b) mutate
+  // widget DOM that ProseMirror owns, causing the widget to re-render
+  // and visually drop on click-away. Suggestion decorations always carry
+  // `data-suggestion-id`, so we use that as the exclusion marker.
   return editorDom.querySelectorAll<HTMLElement>(
-    `[data-comment-id="${safeId}"]`,
+    `[data-comment-id="${safeId}"]:not([data-suggestion-id])`,
   );
 };
 

--- a/package/extensions/comment/comment.ts
+++ b/package/extensions/comment/comment.ts
@@ -3,6 +3,7 @@ import { CommandProps, Mark, mergeAttributes, Range } from '@tiptap/core';
 import { Mark as PMMark } from '@tiptap/pm/model';
 import { Plugin, PluginKey, type EditorState } from '@tiptap/pm/state';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
+import { SuggestionType } from '../../types';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -318,6 +319,10 @@ export interface IComment {
   deleted?: boolean;
   commentIndex?: number;
   version?: string;
+  isSuggestion?: boolean;
+  suggestionType?: SuggestionType;
+  originalContent?: string;
+  suggestedContent?: string;
 }
 
 export const CommentExtension = Mark.create<CommentOptions, CommentStorage>({

--- a/package/extensions/multi-column/menus/columns-menu.tsx
+++ b/package/extensions/multi-column/menus/columns-menu.tsx
@@ -6,18 +6,21 @@ import getRenderContainer from '../../../utils/get-render-container';
 import { Toolbar } from '../../../common/toolbar';
 import { MenuProps } from '../../../common/types';
 import ToolbarButton from '../../../common/toolbar-button';
+import { useEditingContext } from '../../../hooks/use-editing-context';
 
 export const ColumnsMenu = ({ editor, appendTo }: MenuProps) => {
+  const { isSuggestionMode } = useEditingContext();
+
   const getReferenceClientRect = useCallback(() => {
     const renderContainer = getRenderContainer(editor, 'columns');
     return renderContainer;
   }, [editor]);
 
   const shouldShow = useCallback(() => {
-    const isPreviewMode = !editor.isEditable;
+    const isPreviewMode = !editor.isEditable || !!isSuggestionMode;
     const isColumns = editor.isActive('columns');
     return isColumns && !isPreviewMode;
-  }, [editor]);
+  }, [editor, isSuggestionMode]);
 
   const onColumnLeft = useCallback(() => {
     editor.chain().focus().setLayout(ColumnLayout.AlignLeft).run();

--- a/package/extensions/suggestion/suggestion-tracking-extension.ts
+++ b/package/extensions/suggestion/suggestion-tracking-extension.ts
@@ -1,0 +1,314 @@
+/**
+ * SuggestionTrackingExtension
+ *
+ * Captures viewer edits in suggestion mode and shows suggestion decorations
+ * in real-time as the user types — no blur required.
+ *
+ * Approach (V1):
+ * - onSelectionUpdate: capture Yjs RelativePosition anchors + original content.
+ * - appendTransaction: accumulate inserted text / track deletions, upsert a
+ *   live CommentAnchor so the decoration rebuilds on every keystroke.
+ * - onSelectionUpdate (manual cursor move) / onBlur: finalize the suggestion
+ *   by calling onSuggestionReady for persistence.
+ * - Does NOT modify the document (no marks, no re-insertions).
+ */
+
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { ReplaceStep } from '@tiptap/pm/transform';
+import {
+  ySyncPluginKey,
+  absolutePositionToRelativePosition,
+} from '@tiptap/y-tiptap';
+import * as Y from 'yjs';
+import uuid from 'react-uuid';
+import { SuggestionType } from '../../types';
+import {
+  CommentAnchor,
+  triggerDecorationRebuild,
+} from '../comment/comment-decoration-plugin';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface SuggestionReadyData {
+  suggestionId: string;
+  anchorFrom: Y.RelativePosition;
+  anchorTo: Y.RelativePosition;
+  suggestionType: SuggestionType;
+  originalContent: string;
+  suggestedContent: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal state
+// ---------------------------------------------------------------------------
+
+interface PendingSuggestionContext {
+  suggestionId: string;
+  anchorFrom: Y.RelativePosition;
+  anchorTo: Y.RelativePosition;
+  selectionFrom: number;
+  selectionTo: number;
+  originalContent: string;
+  /** Accumulated text from all insert slices since context was captured. */
+  insertedText: string;
+  /** True if at least one ReplaceStep had a non-empty deletion range. */
+  hadDeletion: boolean;
+  /** True once at least one tracked docChanged transaction has arrived. */
+  hasEdits: boolean;
+  /** True once submitted via onSuggestionReady (prevents double-submit). */
+  finalized: boolean;
+}
+
+// PluginKey for internal use
+export const suggestionTrackingPluginKey = new PluginKey<null>(
+  'suggestionTracking',
+);
+
+// ---------------------------------------------------------------------------
+// Extension options
+// ---------------------------------------------------------------------------
+
+export interface SuggestionTrackingOptions {
+  /** Returns true when the editor is in suggestion mode. */
+  getIsSuggestionMode: () => boolean;
+  /**
+   * Called on every keystroke to upsert the live anchor into commentAnchorsRef
+   * so the decoration rebuilds immediately.
+   */
+  onLiveSuggestion: ((anchor: CommentAnchor) => void) | null;
+  /**
+   * Called once when the suggestion is finalized (cursor moves away or blur).
+   * Used for persistence — anchor is already in commentAnchorsRef at this point.
+   */
+  onSuggestionReady: ((data: SuggestionReadyData) => void) | null;
+}
+
+// ---------------------------------------------------------------------------
+// Extension storage (shared across ALL lifecycle hooks and plugin closures)
+// ---------------------------------------------------------------------------
+
+interface SuggestionTrackingStorage {
+  pendingContext: PendingSuggestionContext | null;
+  /**
+   * Set true by appendTransaction on doc-changing transactions.
+   * Read + reset by onSelectionUpdate to distinguish typing vs. manual click.
+   */
+  lastTransactionWasDocChange: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function deriveSuggestionType(
+  context: PendingSuggestionContext,
+): SuggestionType {
+  if (context.hadDeletion) {
+    return context.insertedText.length > 0 ? 'replace' : 'delete';
+  }
+  return 'add';
+}
+
+function buildLiveAnchor(context: PendingSuggestionContext): CommentAnchor {
+  return {
+    id: context.suggestionId,
+    anchorFrom: context.anchorFrom,
+    anchorTo: context.anchorTo,
+    resolved: false,
+    deleted: false,
+    isSuggestion: true,
+    suggestionType: deriveSuggestionType(context),
+    originalContent: context.originalContent,
+    suggestedContent: context.insertedText,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Extension
+// ---------------------------------------------------------------------------
+
+export const SuggestionTrackingExtension = Extension.create<
+  SuggestionTrackingOptions,
+  SuggestionTrackingStorage
+>({
+  name: 'suggestionTracking',
+
+  addOptions() {
+    return {
+      getIsSuggestionMode: () => false,
+      onLiveSuggestion: null,
+      onSuggestionReady: null,
+    };
+  },
+
+  addStorage() {
+    return {
+      pendingContext: null,
+      lastTransactionWasDocChange: false,
+    };
+  },
+
+  // -------------------------------------------------------------------------
+  // onSelectionUpdate
+  //
+  // 1. If the selection changed due to a manual click (not typing) and there
+  //    is an unfinalized pending suggestion → finalize it.
+  // 2. Capture fresh Yjs anchors for the new cursor/selection position.
+  // -------------------------------------------------------------------------
+
+  onSelectionUpdate() {
+    const { getIsSuggestionMode, onSuggestionReady } = this.options;
+    if (!getIsSuggestionMode()) return;
+
+    const wasTyping = this.storage.lastTransactionWasDocChange;
+    this.storage.lastTransactionWasDocChange = false;
+
+    // Typing moves the cursor — keep the existing context so insertedText
+    // keeps accumulating across keystrokes.
+    if (wasTyping) return;
+
+    // Manual cursor movement — finalize any unsubmitted suggestion first.
+    const prev = this.storage.pendingContext;
+    if (prev?.hasEdits && !prev.finalized && onSuggestionReady) {
+      prev.finalized = true;
+      onSuggestionReady({
+        suggestionId: prev.suggestionId,
+        anchorFrom: prev.anchorFrom,
+        anchorTo: prev.anchorTo,
+        suggestionType: deriveSuggestionType(prev),
+        originalContent: prev.originalContent,
+        suggestedContent: prev.insertedText,
+      });
+    }
+
+    const { editor } = this;
+    const { from, to } = editor.state.selection;
+    const syncState = ySyncPluginKey.getState(editor.state);
+    if (!syncState?.binding) return;
+
+    const { type, binding } = syncState;
+
+    try {
+      const anchorFrom = absolutePositionToRelativePosition(
+        from,
+        type,
+        binding.mapping,
+      );
+      const anchorTo = absolutePositionToRelativePosition(
+        to,
+        type,
+        binding.mapping,
+      );
+
+      this.storage.pendingContext = {
+        suggestionId: `comment-${uuid()}`,
+        anchorFrom,
+        anchorTo,
+        selectionFrom: from,
+        selectionTo: to,
+        originalContent: editor.state.doc.textBetween(from, to, '\n'),
+        insertedText: '',
+        hadDeletion: false,
+        hasEdits: false,
+        finalized: false,
+      };
+    } catch {
+      // Yjs binding not ready — skip
+    }
+  },
+
+  // -------------------------------------------------------------------------
+  // onBlur — finalize if not yet done (e.g. user tabs out of editor)
+  // -------------------------------------------------------------------------
+
+  onBlur() {
+    const { getIsSuggestionMode, onSuggestionReady } = this.options;
+    if (!getIsSuggestionMode()) return;
+
+    const context = this.storage.pendingContext;
+    if (!context?.hasEdits || context.finalized || !onSuggestionReady) return;
+
+    context.finalized = true;
+    onSuggestionReady({
+      suggestionId: context.suggestionId,
+      anchorFrom: context.anchorFrom,
+      anchorTo: context.anchorTo,
+      suggestionType: deriveSuggestionType(context),
+      originalContent: context.originalContent,
+      suggestedContent: context.insertedText,
+    });
+  },
+
+  // -------------------------------------------------------------------------
+  // ProseMirror plugin — accumulate edits + trigger live decoration
+  // -------------------------------------------------------------------------
+
+  addProseMirrorPlugins() {
+    const storage = this.storage;
+    const getOptions = () => this.options;
+    // Capture a getter so appendTransaction can reach the TipTap editor.
+    const getEditor = () => this.editor;
+
+    return [
+      new Plugin({
+        key: suggestionTrackingPluginKey,
+
+        appendTransaction(transactions) {
+          const { getIsSuggestionMode, onLiveSuggestion } = getOptions();
+          if (!getIsSuggestionMode()) return null;
+
+          for (const tr of transactions) {
+            if (tr.getMeta('y-sync$')) return null;
+            if (tr.getMeta(suggestionTrackingPluginKey)) return null;
+          }
+
+          if (!transactions.some((tr) => tr.docChanged)) return null;
+
+          const context = storage.pendingContext;
+          if (!context) return null;
+
+          storage.lastTransactionWasDocChange = true;
+
+          for (const tr of transactions) {
+            if (!tr.docChanged) continue;
+            for (const step of tr.steps) {
+              if (!(step instanceof ReplaceStep)) continue;
+
+              if (step.from < step.to) {
+                context.hadDeletion = true;
+              }
+
+              if (step.slice.size > 0) {
+                context.insertedText += step.slice.content.textBetween(
+                  0,
+                  step.slice.content.size,
+                  '',
+                );
+              }
+
+              context.hasEdits = true;
+            }
+          }
+
+          if (!context.hasEdits) return null;
+
+          // Update commentAnchorsRef with the live anchor, then schedule a
+          // decoration rebuild outside this transaction (setTimeout avoids
+          // dispatching during an ongoing dispatch).
+          onLiveSuggestion?.(buildLiveAnchor(context));
+          setTimeout(() => {
+            const editor = getEditor();
+            if (editor && !editor.isDestroyed) {
+              triggerDecorationRebuild(editor);
+            }
+          }, 0);
+
+          return null;
+        },
+      }),
+    ];
+  },
+});

--- a/package/extensions/suggestion/suggestion-tracking-extension.ts
+++ b/package/extensions/suggestion/suggestion-tracking-extension.ts
@@ -51,6 +51,9 @@ export interface SuggestionTrackingOptions {
   /** Viewer presses Backspace/Delete with a non-empty selection. */
   onDeleteSelection: (from: number, to: number) => void;
 
+  /** Viewer pastes a link over selected text. */
+  onPasteLink: (from: number, to: number, href: string) => void;
+
   /**
    * Viewer presses Backspace/Delete with a collapsed cursor.
    * The consumer decides whether this should shrink an active draft or create
@@ -159,6 +162,23 @@ function hasNonCollapsedDomSelection(view: EditorView): boolean {
   );
 }
 
+function normalizePastedHref(text: string): string | null {
+  const href = text.trim();
+  if (!href || /\s/.test(href) || href.includes('@')) {
+    return null;
+  }
+
+  const urlPattern = /^(https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?$/i;
+
+  if (!urlPattern.test(href)) {
+    return null;
+  }
+
+  return href.startsWith('http://') || href.startsWith('https://')
+    ? href
+    : `https://${href}`;
+}
+
 // ---------------------------------------------------------------------------
 // Extension
 // ---------------------------------------------------------------------------
@@ -166,6 +186,7 @@ function hasNonCollapsedDomSelection(view: EditorView): boolean {
 export const SuggestionTrackingExtension =
   Extension.create<SuggestionTrackingOptions>({
     name: 'suggestionTracking',
+    priority: 1001,
 
     addOptions() {
       return {
@@ -173,6 +194,7 @@ export const SuggestionTrackingExtension =
         onTextInput: () => {},
         onReplaceTyping: () => {},
         onDeleteSelection: () => {},
+        onPasteLink: () => {},
         onDeleteAtCursor: () => {},
         onDeleteRangeWithoutSelection: () => {},
         onUndo: () => {},
@@ -350,9 +372,26 @@ export const SuggestionTrackingExtension =
               return false;
             },
 
-            // ----- Paste / Drop — blocked in v1 -----------------------------
-            handlePaste() {
-              return getOptions().getIsSuggestionMode();
+            // ----- Paste / Drop ---------------------------------------------
+            // In suggestion mode, regular paste is blocked so the document
+            // stays immutable. The one allowed paste gesture is select text +
+            // paste a URL, which creates a link suggestion over that range.
+            handlePaste(view, event) {
+              const opts = getOptions();
+              if (!opts.getIsSuggestionMode()) return false;
+
+              event.preventDefault();
+              const { from, to } = view.state.selection;
+              const pastedHref = normalizePastedHref(
+                event.clipboardData?.getData('text/plain') ?? '',
+              );
+
+              if (from < to && pastedHref) {
+                opts.onPasteLink(from, to, pastedHref);
+                return true;
+              }
+
+              return true;
             },
             handleDrop() {
               return getOptions().getIsSuggestionMode();
@@ -455,6 +494,17 @@ export const SuggestionTrackingExtension =
                   inputType === 'insertReplacementText'
                 ) {
                   event.preventDefault();
+                  const pastedHref = normalizePastedHref(
+                    (
+                      event as InputEvent & {
+                        dataTransfer?: DataTransfer | null;
+                      }
+                    ).dataTransfer?.getData('text/plain') ?? '',
+                  );
+                  const { from, to } = view.state.selection;
+                  if (from < to && pastedHref) {
+                    opts.onPasteLink(from, to, pastedHref);
+                  }
                   return true;
                 }
 

--- a/package/extensions/suggestion/suggestion-tracking-extension.ts
+++ b/package/extensions/suggestion/suggestion-tracking-extension.ts
@@ -1,29 +1,30 @@
 /**
- * SuggestionTrackingExtension — Phase 0 stub.
+ * SuggestionTrackingExtension
  *
- * Under the new architecture (see docs/architecture/suggestion-mode-architecture.md),
- * this extension intercepts keystrokes via ProseMirror plugin `props.handle*`
- * callbacks and routes pending changes to the Zustand store. The document is
- * never modified by typing in suggestion mode — only the owner's Accept path
- * modifies it.
+ * Intercepts viewer keystrokes in suggestion mode and routes them to the
+ * Zustand store as pending-draft actions. The ProseMirror document is never
+ * modified by this extension — typed text is captured as a proposed change,
+ * rendered as a decoration overlay via the draft anchor layer.
  *
- * This file is an inert stub during Phase 0–2:
- *   - The extension exists and is wired into the editor so consumers do not
- *     need to branch on its presence.
- *   - It has no plugins, no lifecycle hooks, and no commands.
- *   - Toggling suggestion mode in the UI currently does nothing.
+ * Design: props-based plugin (handleKeyDown, handleTextInput, handlePaste,
+ * handleDrop). Each handler returns true to block the default behavior when
+ * suggestion mode is active; the extension never dispatches a doc-modifying
+ * transaction. The only path that modifies the doc in the entire suggestion
+ * system is applyAcceptedSuggestion on owner Accept.
  *
- * Phase 3 replaces this stub with the real keystroke-interception plugin.
+ * See docs/architecture/suggestion-mode-architecture.md for the full model.
  */
 
 import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
 import * as Y from 'yjs';
 import { SuggestionType } from '../../types';
 import type { CommentAnchor } from '../comment/comment-decoration-plugin';
 
 // ---------------------------------------------------------------------------
-// Public types — kept stable so use-tab-editor.tsx and consumer integrations
-// do not need to change between phases.
+// Public types — kept for downstream import compatibility. SuggestionReadyData
+// is unused by the new model (submit goes through the store, not a TipTap
+// command) but exported so consumers that reference the type still compile.
 // ---------------------------------------------------------------------------
 
 export interface SuggestionReadyData {
@@ -38,20 +39,68 @@ export interface SuggestionReadyData {
 export interface SuggestionTrackingOptions {
   /** Returns true when the editor is in suggestion mode. */
   getIsSuggestionMode: () => boolean;
-  /**
-   * Phase-3-and-later: called on every keystroke with the live anchor.
-   * No-op during the Phase 0 stub.
-   */
-  onLiveSuggestion: ((anchor: CommentAnchor) => void) | null;
-  /**
-   * Phase-3-and-later: called when the viewer clicks Submit.
-   * No-op during the Phase 0 stub.
-   */
-  onSuggestionReady: ((data: SuggestionReadyData) => void) | null;
+
+  /** Viewer types text with a collapsed cursor (Add gesture). */
+  onTextInput: (text: string) => void;
+
+  /** Viewer types text over a non-empty selection (Replace gesture). */
+  onReplaceTyping: (from: number, to: number, text: string) => void;
+
+  /** Viewer presses Backspace/Delete with a non-empty selection. */
+  onDeleteSelection: (from: number, to: number) => void;
+
+  /** Viewer presses Cmd+Z (or Ctrl+Z). Shrinks the active draft by one keystroke. */
+  onUndo: () => void;
+
+  // Legacy — unused by the new model, retained as optional for backwards
+  // compatibility with any consumer that still passes them.
+  onLiveSuggestion?: ((anchor: CommentAnchor) => void) | null;
+  onSuggestionReady?: ((data: SuggestionReadyData) => void) | null;
 }
 
 // ---------------------------------------------------------------------------
-// Stub extension — no behavior. Replaced in Phase 3.
+// Plugin key — exposed so provider / debug tooling can set transaction metas
+// that this plugin should ignore (e.g. cursor-only adjustments). Currently
+// the plugin doesn't read meta; the key is reserved for future use.
+// ---------------------------------------------------------------------------
+
+export const suggestionTrackingPluginKey = new PluginKey<null>(
+  'suggestionTracking',
+);
+
+// ---------------------------------------------------------------------------
+// Keystroke classification helpers
+// ---------------------------------------------------------------------------
+
+function isFormattingShortcut(event: KeyboardEvent): boolean {
+  // Cmd/Ctrl + B / I / U — bold, italic, underline. Shift+... for strike in
+  // some bindings; block that conservatively too.
+  const isMod = event.metaKey || event.ctrlKey;
+  if (!isMod) return false;
+  const key = event.key.toLowerCase();
+  return key === 'b' || key === 'i' || key === 'u';
+}
+
+function isUndoShortcut(event: KeyboardEvent): boolean {
+  const isMod = event.metaKey || event.ctrlKey;
+  return isMod && !event.shiftKey && event.key.toLowerCase() === 'z';
+}
+
+function isRedoShortcut(event: KeyboardEvent): boolean {
+  // Cmd+Shift+Z (mac) and Cmd+Y (win). Also Ctrl+Y.
+  const isMod = event.metaKey || event.ctrlKey;
+  if (!isMod) return false;
+  const key = event.key.toLowerCase();
+  return (event.shiftKey && key === 'z') || key === 'y';
+}
+
+function isCutShortcut(event: KeyboardEvent): boolean {
+  const isMod = event.metaKey || event.ctrlKey;
+  return isMod && event.key.toLowerCase() === 'x';
+}
+
+// ---------------------------------------------------------------------------
+// Extension
 // ---------------------------------------------------------------------------
 
 export const SuggestionTrackingExtension =
@@ -61,8 +110,99 @@ export const SuggestionTrackingExtension =
     addOptions() {
       return {
         getIsSuggestionMode: () => false,
+        onTextInput: () => {},
+        onReplaceTyping: () => {},
+        onDeleteSelection: () => {},
+        onUndo: () => {},
         onLiveSuggestion: null,
         onSuggestionReady: null,
       };
+    },
+
+    addProseMirrorPlugins() {
+      const getOptions = () => this.options;
+
+      return [
+        new Plugin({
+          key: suggestionTrackingPluginKey,
+
+          props: {
+            // ----- Text input ------------------------------------------------
+            // Fires for ordinary typing (including post-composition IME commit).
+            // If a selection is active, treat as Replace gesture; otherwise Add.
+            handleTextInput(_view, from, to, text) {
+              const opts = getOptions();
+              if (!opts.getIsSuggestionMode()) return false;
+
+              if (from < to) {
+                opts.onReplaceTyping(from, to, text);
+              } else {
+                opts.onTextInput(text);
+              }
+              return true;
+            },
+
+            // ----- Key down --------------------------------------------------
+            // Handle non-text keys: Backspace/Delete, Enter, Tab, Cmd+Z, blocked
+            // shortcuts. Return true for anything we want to block or intercept.
+            handleKeyDown(view, event) {
+              const opts = getOptions();
+              if (!opts.getIsSuggestionMode()) return false;
+
+              const { from, to } = view.state.selection;
+
+              // Backspace / Delete: Delete draft from selection, else no-op
+              if (event.key === 'Backspace' || event.key === 'Delete') {
+                if (from < to) {
+                  opts.onDeleteSelection(from, to);
+                }
+                return true;
+              }
+
+              // Enter / Tab — blocked per v1 spec
+              if (event.key === 'Enter' || event.key === 'Tab') {
+                return true;
+              }
+
+              // Escape — no-op but block to be explicit
+              if (event.key === 'Escape') {
+                return true;
+              }
+
+              // Cmd+Z — shrink active draft; block default editor undo
+              if (isUndoShortcut(event)) {
+                opts.onUndo();
+                return true;
+              }
+
+              // Cmd+Shift+Z / Cmd+Y — redo blocked in v1
+              if (isRedoShortcut(event)) {
+                return true;
+              }
+
+              // Formatting shortcuts — blocked (v1 tracks content only)
+              if (isFormattingShortcut(event)) {
+                return true;
+              }
+
+              // Cut — blocked (would remove text from the doc)
+              if (isCutShortcut(event)) {
+                return true;
+              }
+
+              // Everything else (navigation, Cmd+A, Cmd+C, etc.) — let PM handle
+              return false;
+            },
+
+            // ----- Paste / Drop — blocked in v1 -----------------------------
+            handlePaste(_view, _event) {
+              return getOptions().getIsSuggestionMode();
+            },
+            handleDrop(_view, _event) {
+              return getOptions().getIsSuggestionMode();
+            },
+          },
+        }),
+      ];
     },
   });

--- a/package/extensions/suggestion/suggestion-tracking-extension.ts
+++ b/package/extensions/suggestion/suggestion-tracking-extension.ts
@@ -50,6 +50,21 @@ export interface SuggestionTrackingOptions {
   /** Viewer presses Backspace/Delete with a non-empty selection. */
   onDeleteSelection: (from: number, to: number) => void;
 
+  /**
+   * Viewer presses Backspace/Delete with a collapsed cursor.
+   * The consumer decides whether this should shrink an active draft or create
+   * a new one-character delete suggestion at the caret.
+   */
+  onDeleteAtCursor: (direction: 'backward' | 'forward') => void;
+
+  /**
+   * Browser attempted to delete a concrete range without an explicit
+   * user selection (for example, a beforeinput/IME path that bypassed
+   * keydown). Lets the consumer preserve "undo active draft" semantics
+   * while still creating delete drafts for normal text.
+   */
+  onDeleteRangeWithoutSelection: (from: number, to: number) => void;
+
   /** Viewer presses Cmd+Z (or Ctrl+Z). Shrinks the active draft by one keystroke. */
   onUndo: () => void;
 
@@ -114,6 +129,8 @@ export const SuggestionTrackingExtension =
         onTextInput: () => {},
         onReplaceTyping: () => {},
         onDeleteSelection: () => {},
+        onDeleteAtCursor: () => {},
+        onDeleteRangeWithoutSelection: () => {},
         onUndo: () => {},
         onLiveSuggestion: null,
         onSuggestionReady: null,
@@ -141,9 +158,9 @@ export const SuggestionTrackingExtension =
             if (tr.getMeta('y-sync$')) return true;
 
             // Pre-transaction selection tells us whether the user had a
-            // range selected. Without a selection, a deletion is "bare
-            // backspace in active draft" — we shrink the draft instead of
-            // creating a Delete suggestion.
+            // range selected. Without a selection, we still need the
+            // pre-change state so the consumer can decide between shrinking
+            // an active draft and creating a delete suggestion.
             const hadSelection = state.selection.from < state.selection.to;
 
             // Classify the transaction by inspecting its steps:
@@ -195,10 +212,13 @@ export const SuggestionTrackingExtension =
                   // User selected text and pressed Backspace/Delete
                   opts.onDeleteSelection(deletedRange.from, deletedRange.to);
                 } else if (deletedRange) {
-                  // Bare backspace (no user selection) inside an active draft
-                  // → shrink the active draft instead of creating a 1-char
-                  // Delete suggestion. Silent no-op if no active draft.
-                  opts.onUndo();
+                  // A browser path deleted a concrete range without an
+                  // explicit selection. Let the consumer decide whether to
+                  // undo an active draft or promote this into a delete draft.
+                  opts.onDeleteRangeWithoutSelection(
+                    deletedRange.from,
+                    deletedRange.to,
+                  );
                 } else if (insertedText) {
                   opts.onTextInput(insertedText);
                 }
@@ -237,15 +257,16 @@ export const SuggestionTrackingExtension =
 
               // Backspace / Delete:
               //   - with selection → Delete draft
-              //   - without selection → treat as undo of the active draft's
-              //     last keystroke (feels like Google Docs while typing).
-              //     When no draft is at the cursor, this is a silent no-op
-              //     per spec.
+              //   - without selection → consumer decides between shrinking
+              //     the active draft and creating a new delete suggestion at
+              //     the cursor.
               if (event.key === 'Backspace' || event.key === 'Delete') {
                 if (from < to) {
                   opts.onDeleteSelection(from, to);
                 } else {
-                  opts.onUndo();
+                  opts.onDeleteAtCursor(
+                    event.key === 'Backspace' ? 'backward' : 'forward',
+                  );
                 }
                 return true;
               }
@@ -312,12 +333,30 @@ export const SuggestionTrackingExtension =
                   inputType === 'deleteByCut' ||
                   inputType === 'deleteByDrag'
                 ) {
-                  event.preventDefault();
                   const { from, to } = view.state.selection;
                   if (from < to) {
+                    event.preventDefault();
                     opts.onDeleteSelection(from, to);
+                    return true;
                   }
-                  return true;
+
+                  // Simple collapsed-caret delete paths should behave the
+                  // same as keydown. Wider-range browser deletes (word/cut/
+                  // drag) fall through so filterTransaction can inspect the
+                  // actual deleted range and convert it into a draft.
+                  if (inputType === 'deleteContentBackward') {
+                    event.preventDefault();
+                    opts.onDeleteAtCursor('backward');
+                    return true;
+                  }
+
+                  if (inputType === 'deleteContentForward') {
+                    event.preventDefault();
+                    opts.onDeleteAtCursor('forward');
+                    return true;
+                  }
+
+                  return false;
                 }
 
                 // Paste / drop routes through beforeinput too on some browsers

--- a/package/extensions/suggestion/suggestion-tracking-extension.ts
+++ b/package/extensions/suggestion/suggestion-tracking-extension.ts
@@ -17,6 +17,7 @@
 
 import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { ReplaceStep } from '@tiptap/pm/transform';
 import * as Y from 'yjs';
 import { SuggestionType } from '../../types';
 import type { CommentAnchor } from '../comment/comment-decoration-plugin';
@@ -126,6 +127,89 @@ export const SuggestionTrackingExtension =
         new Plugin({
           key: suggestionTrackingPluginKey,
 
+          // Safety net: some deletion paths (double-click word select +
+          // Backspace, IME delete, beforeinput-driven deletions) bypass
+          // handleKeyDown and handleDOMEvents entirely. filterTransaction
+          // catches EVERY transaction before dispatch — if one is about to
+          // modify the doc while in suggest mode, we cancel it and schedule
+          // the matching draft action.
+          filterTransaction(tr, state) {
+            const opts = getOptions();
+            if (!opts.getIsSuggestionMode()) return true;
+            if (!tr.docChanged) return true;
+            if (tr.getMeta(suggestionTrackingPluginKey)) return true;
+            if (tr.getMeta('y-sync$')) return true;
+
+            // Pre-transaction selection tells us whether the user had a
+            // range selected. Without a selection, a deletion is "bare
+            // backspace in active draft" — we shrink the draft instead of
+            // creating a Delete suggestion.
+            const hadSelection = state.selection.from < state.selection.to;
+
+            // Classify the transaction by inspecting its steps:
+            //   - deletedRange: a pure text-range deletion
+            //   - insertedText: pure text content being inserted
+            //   - hasStructuralChange: boundaries / node splits / non-ReplaceSteps
+            // Enter, Tab, paste-with-structure, drag, etc. produce structural
+            // changes — we block those silently (no draft action).
+            let deletedRange: { from: number; to: number } | null = null;
+            let insertedText = '';
+            let hasStructuralChange = false;
+
+            for (const step of tr.steps) {
+              if (!(step instanceof ReplaceStep)) {
+                hasStructuralChange = true;
+                continue;
+              }
+              if (step.slice.openStart > 0 || step.slice.openEnd > 0) {
+                hasStructuralChange = true;
+              }
+              if (step.from < step.to) {
+                deletedRange = { from: step.from, to: step.to };
+              }
+              if (step.slice.size > 0) {
+                insertedText += step.slice.content.textBetween(
+                  0,
+                  step.slice.content.size,
+                  '',
+                );
+              }
+            }
+
+            // Structural changes (Enter, Tab, paste-with-blocks, node splits)
+            // are blocked silently per spec ("blocked gestures simply do nothing").
+            if (hasStructuralChange) {
+              return false;
+            }
+
+            // Pure text change: translate to a draft action.
+            if (deletedRange || insertedText) {
+              setTimeout(() => {
+                if (deletedRange && insertedText) {
+                  opts.onReplaceTyping(
+                    deletedRange.from,
+                    deletedRange.to,
+                    insertedText,
+                  );
+                } else if (deletedRange && hadSelection) {
+                  // User selected text and pressed Backspace/Delete
+                  opts.onDeleteSelection(deletedRange.from, deletedRange.to);
+                } else if (deletedRange) {
+                  // Bare backspace (no user selection) inside an active draft
+                  // → shrink the active draft instead of creating a 1-char
+                  // Delete suggestion. Silent no-op if no active draft.
+                  opts.onUndo();
+                } else if (insertedText) {
+                  opts.onTextInput(insertedText);
+                }
+              }, 0);
+            }
+
+            // Always block any doc-changing transaction in suggest mode — the
+            // document is only modified on owner Accept.
+            return false;
+          },
+
           props: {
             // ----- Text input ------------------------------------------------
             // Fires for ordinary typing (including post-composition IME commit).
@@ -151,10 +235,17 @@ export const SuggestionTrackingExtension =
 
               const { from, to } = view.state.selection;
 
-              // Backspace / Delete: Delete draft from selection, else no-op
+              // Backspace / Delete:
+              //   - with selection → Delete draft
+              //   - without selection → treat as undo of the active draft's
+              //     last keystroke (feels like Google Docs while typing).
+              //     When no draft is at the cursor, this is a silent no-op
+              //     per spec.
               if (event.key === 'Backspace' || event.key === 'Delete') {
                 if (from < to) {
                   opts.onDeleteSelection(from, to);
+                } else {
+                  opts.onUndo();
                 }
                 return true;
               }
@@ -200,6 +291,50 @@ export const SuggestionTrackingExtension =
             },
             handleDrop(_view, _event) {
               return getOptions().getIsSuggestionMode();
+            },
+
+            // ----- DOM beforeinput — catches deletion paths that bypass
+            // handleKeyDown (browser-native selection + Backspace on some
+            // browsers fires only beforeinput, not keydown).
+            handleDOMEvents: {
+              beforeinput: (view, event) => {
+                const opts = getOptions();
+                if (!opts.getIsSuggestionMode()) return false;
+
+                const inputType = event.inputType;
+
+                // Selection deletion: capture selection before browser mutates
+                if (
+                  inputType === 'deleteContentBackward' ||
+                  inputType === 'deleteContentForward' ||
+                  inputType === 'deleteWordBackward' ||
+                  inputType === 'deleteWordForward' ||
+                  inputType === 'deleteByCut' ||
+                  inputType === 'deleteByDrag'
+                ) {
+                  event.preventDefault();
+                  const { from, to } = view.state.selection;
+                  if (from < to) {
+                    opts.onDeleteSelection(from, to);
+                  }
+                  return true;
+                }
+
+                // Paste / drop routes through beforeinput too on some browsers
+                if (
+                  inputType === 'insertFromPaste' ||
+                  inputType === 'insertFromPasteAsQuotation' ||
+                  inputType === 'insertFromDrop' ||
+                  inputType === 'insertReplacementText'
+                ) {
+                  event.preventDefault();
+                  return true;
+                }
+
+                // insertText / insertCompositionText — let handleTextInput
+                // deal with it. Return false so PM continues processing.
+                return false;
+              },
             },
           },
         }),

--- a/package/extensions/suggestion/suggestion-tracking-extension.ts
+++ b/package/extensions/suggestion/suggestion-tracking-extension.ts
@@ -18,6 +18,7 @@
 import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import { ReplaceStep } from '@tiptap/pm/transform';
+import type { EditorView } from '@tiptap/pm/view';
 import * as Y from 'yjs';
 import { SuggestionType } from '../../types';
 import type { CommentAnchor } from '../comment/comment-decoration-plugin';
@@ -113,6 +114,49 @@ function isRedoShortcut(event: KeyboardEvent): boolean {
 function isCutShortcut(event: KeyboardEvent): boolean {
   const isMod = event.metaKey || event.ctrlKey;
   return isMod && event.key.toLowerCase() === 'x';
+}
+
+function getBeforeInputTargetRange(
+  view: EditorView,
+  event: InputEvent,
+): { from: number; to: number } | null {
+  const ranges =
+    typeof event.getTargetRanges === 'function' ? event.getTargetRanges() : [];
+  const range = ranges[0];
+
+  if (!range) {
+    return null;
+  }
+
+  try {
+    const from = view.posAtDOM(range.startContainer, range.startOffset);
+    const to = view.posAtDOM(range.endContainer, range.endOffset);
+
+    return {
+      from: Math.min(from, to),
+      to: Math.max(from, to),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function hasNonCollapsedDomSelection(view: EditorView): boolean {
+  const selection = window.getSelection();
+
+  if (!selection || selection.isCollapsed) {
+    return false;
+  }
+
+  const anchorNode = selection.anchorNode;
+  const focusNode = selection.focusNode;
+
+  return Boolean(
+    anchorNode &&
+      focusNode &&
+      view.dom.contains(anchorNode) &&
+      view.dom.contains(focusNode),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -307,10 +351,10 @@ export const SuggestionTrackingExtension =
             },
 
             // ----- Paste / Drop — blocked in v1 -----------------------------
-            handlePaste(_view, _event) {
+            handlePaste() {
               return getOptions().getIsSuggestionMode();
             },
-            handleDrop(_view, _event) {
+            handleDrop() {
               return getOptions().getIsSuggestionMode();
             },
 
@@ -323,6 +367,10 @@ export const SuggestionTrackingExtension =
                 if (!opts.getIsSuggestionMode()) return false;
 
                 const inputType = event.inputType;
+                const targetRange = getBeforeInputTargetRange(view, event);
+                const hasTargetRange = Boolean(
+                  targetRange && targetRange.from < targetRange.to,
+                );
 
                 // Selection deletion: capture selection before browser mutates
                 if (
@@ -337,6 +385,19 @@ export const SuggestionTrackingExtension =
                   if (from < to) {
                     event.preventDefault();
                     opts.onDeleteSelection(from, to);
+                    return true;
+                  }
+
+                  if (targetRange && hasTargetRange) {
+                    event.preventDefault();
+                    if (hasNonCollapsedDomSelection(view)) {
+                      opts.onDeleteSelection(targetRange.from, targetRange.to);
+                    } else {
+                      opts.onDeleteRangeWithoutSelection(
+                        targetRange.from,
+                        targetRange.to,
+                      );
+                    }
                     return true;
                   }
 
@@ -357,6 +418,33 @@ export const SuggestionTrackingExtension =
                   }
 
                   return false;
+                }
+
+                if (inputType === 'insertText') {
+                  const text = event.data ?? '';
+                  if (!text) {
+                    return false;
+                  }
+
+                  const { from, to } = view.state.selection;
+                  event.preventDefault();
+
+                  if (from < to) {
+                    opts.onReplaceTyping(from, to, text);
+                    return true;
+                  }
+
+                  if (targetRange && hasTargetRange) {
+                    opts.onReplaceTyping(
+                      targetRange.from,
+                      targetRange.to,
+                      text,
+                    );
+                    return true;
+                  }
+
+                  opts.onTextInput(text);
+                  return true;
                 }
 
                 // Paste / drop routes through beforeinput too on some browsers

--- a/package/extensions/suggestion/suggestion-tracking-extension.ts
+++ b/package/extensions/suggestion/suggestion-tracking-extension.ts
@@ -1,35 +1,29 @@
 /**
- * SuggestionTrackingExtension
+ * SuggestionTrackingExtension — Phase 0 stub.
  *
- * Captures viewer edits in suggestion mode and shows suggestion decorations
- * in real-time as the user types — no blur required.
+ * Under the new architecture (see docs/architecture/suggestion-mode-architecture.md),
+ * this extension intercepts keystrokes via ProseMirror plugin `props.handle*`
+ * callbacks and routes pending changes to the Zustand store. The document is
+ * never modified by typing in suggestion mode — only the owner's Accept path
+ * modifies it.
  *
- * Approach (V1):
- * - onSelectionUpdate: capture Yjs RelativePosition anchors + original content.
- * - appendTransaction: accumulate inserted text / track deletions, upsert a
- *   live CommentAnchor so the decoration rebuilds on every keystroke.
- * - onSelectionUpdate (manual cursor move) / onBlur: finalize the suggestion
- *   by calling onSuggestionReady for persistence.
- * - Does NOT modify the document (no marks, no re-insertions).
+ * This file is an inert stub during Phase 0–2:
+ *   - The extension exists and is wired into the editor so consumers do not
+ *     need to branch on its presence.
+ *   - It has no plugins, no lifecycle hooks, and no commands.
+ *   - Toggling suggestion mode in the UI currently does nothing.
+ *
+ * Phase 3 replaces this stub with the real keystroke-interception plugin.
  */
 
 import { Extension } from '@tiptap/core';
-import { Plugin, PluginKey } from '@tiptap/pm/state';
-import { ReplaceStep } from '@tiptap/pm/transform';
-import {
-  ySyncPluginKey,
-  absolutePositionToRelativePosition,
-} from '@tiptap/y-tiptap';
 import * as Y from 'yjs';
-import uuid from 'react-uuid';
 import { SuggestionType } from '../../types';
-import {
-  CommentAnchor,
-  triggerDecorationRebuild,
-} from '../comment/comment-decoration-plugin';
+import type { CommentAnchor } from '../comment/comment-decoration-plugin';
 
 // ---------------------------------------------------------------------------
-// Public types
+// Public types — kept stable so use-tab-editor.tsx and consumer integrations
+// do not need to change between phases.
 // ---------------------------------------------------------------------------
 
 export interface SuggestionReadyData {
@@ -41,274 +35,34 @@ export interface SuggestionReadyData {
   suggestedContent: string;
 }
 
-// ---------------------------------------------------------------------------
-// Internal state
-// ---------------------------------------------------------------------------
-
-interface PendingSuggestionContext {
-  suggestionId: string;
-  anchorFrom: Y.RelativePosition;
-  anchorTo: Y.RelativePosition;
-  selectionFrom: number;
-  selectionTo: number;
-  originalContent: string;
-  /** Accumulated text from all insert slices since context was captured. */
-  insertedText: string;
-  /** True if at least one ReplaceStep had a non-empty deletion range. */
-  hadDeletion: boolean;
-  /** True once at least one tracked docChanged transaction has arrived. */
-  hasEdits: boolean;
-  /** True once submitted via onSuggestionReady (prevents double-submit). */
-  finalized: boolean;
-}
-
-// PluginKey for internal use
-export const suggestionTrackingPluginKey = new PluginKey<null>(
-  'suggestionTracking',
-);
-
-// ---------------------------------------------------------------------------
-// Extension options
-// ---------------------------------------------------------------------------
-
 export interface SuggestionTrackingOptions {
   /** Returns true when the editor is in suggestion mode. */
   getIsSuggestionMode: () => boolean;
   /**
-   * Called on every keystroke to upsert the live anchor into commentAnchorsRef
-   * so the decoration rebuilds immediately.
+   * Phase-3-and-later: called on every keystroke with the live anchor.
+   * No-op during the Phase 0 stub.
    */
   onLiveSuggestion: ((anchor: CommentAnchor) => void) | null;
   /**
-   * Called once when the suggestion is finalized (cursor moves away or blur).
-   * Used for persistence — anchor is already in commentAnchorsRef at this point.
+   * Phase-3-and-later: called when the viewer clicks Submit.
+   * No-op during the Phase 0 stub.
    */
   onSuggestionReady: ((data: SuggestionReadyData) => void) | null;
 }
 
 // ---------------------------------------------------------------------------
-// Extension storage (shared across ALL lifecycle hooks and plugin closures)
+// Stub extension — no behavior. Replaced in Phase 3.
 // ---------------------------------------------------------------------------
 
-interface SuggestionTrackingStorage {
-  pendingContext: PendingSuggestionContext | null;
-  /**
-   * Set true by appendTransaction on doc-changing transactions.
-   * Read + reset by onSelectionUpdate to distinguish typing vs. manual click.
-   */
-  lastTransactionWasDocChange: boolean;
-}
+export const SuggestionTrackingExtension =
+  Extension.create<SuggestionTrackingOptions>({
+    name: 'suggestionTracking',
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function deriveSuggestionType(
-  context: PendingSuggestionContext,
-): SuggestionType {
-  if (context.hadDeletion) {
-    return context.insertedText.length > 0 ? 'replace' : 'delete';
-  }
-  return 'add';
-}
-
-function buildLiveAnchor(context: PendingSuggestionContext): CommentAnchor {
-  return {
-    id: context.suggestionId,
-    anchorFrom: context.anchorFrom,
-    anchorTo: context.anchorTo,
-    resolved: false,
-    deleted: false,
-    isSuggestion: true,
-    suggestionType: deriveSuggestionType(context),
-    originalContent: context.originalContent,
-    suggestedContent: context.insertedText,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Extension
-// ---------------------------------------------------------------------------
-
-export const SuggestionTrackingExtension = Extension.create<
-  SuggestionTrackingOptions,
-  SuggestionTrackingStorage
->({
-  name: 'suggestionTracking',
-
-  addOptions() {
-    return {
-      getIsSuggestionMode: () => false,
-      onLiveSuggestion: null,
-      onSuggestionReady: null,
-    };
-  },
-
-  addStorage() {
-    return {
-      pendingContext: null,
-      lastTransactionWasDocChange: false,
-    };
-  },
-
-  // -------------------------------------------------------------------------
-  // onSelectionUpdate
-  //
-  // 1. If the selection changed due to a manual click (not typing) and there
-  //    is an unfinalized pending suggestion → finalize it.
-  // 2. Capture fresh Yjs anchors for the new cursor/selection position.
-  // -------------------------------------------------------------------------
-
-  onSelectionUpdate() {
-    const { getIsSuggestionMode, onSuggestionReady } = this.options;
-    if (!getIsSuggestionMode()) return;
-
-    const wasTyping = this.storage.lastTransactionWasDocChange;
-    this.storage.lastTransactionWasDocChange = false;
-
-    // Typing moves the cursor — keep the existing context so insertedText
-    // keeps accumulating across keystrokes.
-    if (wasTyping) return;
-
-    // Manual cursor movement — finalize any unsubmitted suggestion first.
-    const prev = this.storage.pendingContext;
-    if (prev?.hasEdits && !prev.finalized && onSuggestionReady) {
-      prev.finalized = true;
-      onSuggestionReady({
-        suggestionId: prev.suggestionId,
-        anchorFrom: prev.anchorFrom,
-        anchorTo: prev.anchorTo,
-        suggestionType: deriveSuggestionType(prev),
-        originalContent: prev.originalContent,
-        suggestedContent: prev.insertedText,
-      });
-    }
-
-    const { editor } = this;
-    const { from, to } = editor.state.selection;
-    const syncState = ySyncPluginKey.getState(editor.state);
-    if (!syncState?.binding) return;
-
-    const { type, binding } = syncState;
-
-    try {
-      const anchorFrom = absolutePositionToRelativePosition(
-        from,
-        type,
-        binding.mapping,
-      );
-      const anchorTo = absolutePositionToRelativePosition(
-        to,
-        type,
-        binding.mapping,
-      );
-
-      this.storage.pendingContext = {
-        suggestionId: `comment-${uuid()}`,
-        anchorFrom,
-        anchorTo,
-        selectionFrom: from,
-        selectionTo: to,
-        originalContent: editor.state.doc.textBetween(from, to, '\n'),
-        insertedText: '',
-        hadDeletion: false,
-        hasEdits: false,
-        finalized: false,
+    addOptions() {
+      return {
+        getIsSuggestionMode: () => false,
+        onLiveSuggestion: null,
+        onSuggestionReady: null,
       };
-    } catch {
-      // Yjs binding not ready — skip
-    }
-  },
-
-  // -------------------------------------------------------------------------
-  // onBlur — finalize if not yet done (e.g. user tabs out of editor)
-  // -------------------------------------------------------------------------
-
-  onBlur() {
-    const { getIsSuggestionMode, onSuggestionReady } = this.options;
-    if (!getIsSuggestionMode()) return;
-
-    const context = this.storage.pendingContext;
-    if (!context?.hasEdits || context.finalized || !onSuggestionReady) return;
-
-    context.finalized = true;
-    onSuggestionReady({
-      suggestionId: context.suggestionId,
-      anchorFrom: context.anchorFrom,
-      anchorTo: context.anchorTo,
-      suggestionType: deriveSuggestionType(context),
-      originalContent: context.originalContent,
-      suggestedContent: context.insertedText,
-    });
-  },
-
-  // -------------------------------------------------------------------------
-  // ProseMirror plugin — accumulate edits + trigger live decoration
-  // -------------------------------------------------------------------------
-
-  addProseMirrorPlugins() {
-    const storage = this.storage;
-    const getOptions = () => this.options;
-    // Capture a getter so appendTransaction can reach the TipTap editor.
-    const getEditor = () => this.editor;
-
-    return [
-      new Plugin({
-        key: suggestionTrackingPluginKey,
-
-        appendTransaction(transactions) {
-          const { getIsSuggestionMode, onLiveSuggestion } = getOptions();
-          if (!getIsSuggestionMode()) return null;
-
-          for (const tr of transactions) {
-            if (tr.getMeta('y-sync$')) return null;
-            if (tr.getMeta(suggestionTrackingPluginKey)) return null;
-          }
-
-          if (!transactions.some((tr) => tr.docChanged)) return null;
-
-          const context = storage.pendingContext;
-          if (!context) return null;
-
-          storage.lastTransactionWasDocChange = true;
-
-          for (const tr of transactions) {
-            if (!tr.docChanged) continue;
-            for (const step of tr.steps) {
-              if (!(step instanceof ReplaceStep)) continue;
-
-              if (step.from < step.to) {
-                context.hadDeletion = true;
-              }
-
-              if (step.slice.size > 0) {
-                context.insertedText += step.slice.content.textBetween(
-                  0,
-                  step.slice.content.size,
-                  '',
-                );
-              }
-
-              context.hasEdits = true;
-            }
-          }
-
-          if (!context.hasEdits) return null;
-
-          // Update commentAnchorsRef with the live anchor, then schedule a
-          // decoration rebuild outside this transaction (setTimeout avoids
-          // dispatching during an ongoing dispatch).
-          onLiveSuggestion?.(buildLiveAnchor(context));
-          setTimeout(() => {
-            const editor = getEditor();
-            if (editor && !editor.isDestroyed) {
-              triggerDecorationRebuild(editor);
-            }
-          }, 0);
-
-          return null;
-        },
-      }),
-    ];
-  },
-});
+    },
+  });

--- a/package/hooks/use-editing-context.tsx
+++ b/package/hooks/use-editing-context.tsx
@@ -6,6 +6,7 @@ type EditingContextType = {
   isPreviewMode: boolean;
   isPresentationMode?: boolean;
   isCollaboratorsDoc?: boolean;
+  isSuggestionMode?: boolean;
 };
 
 // Create a Context
@@ -13,6 +14,7 @@ const EditingContext = createContext<EditingContextType>({
   isPreviewMode: false,
   isPresentationMode: false,
   isCollaboratorsDoc: false,
+  isSuggestionMode: false,
 });
 
 // Create a Hook to use this Context
@@ -31,6 +33,7 @@ type EditingProviderProps = {
   isPresentationMode?: boolean;
   isCollaboratorsDoc?: boolean;
   isPreviewEditor?: boolean;
+  isSuggestionMode?: boolean;
 };
 
 // Create a Provider Component
@@ -40,6 +43,7 @@ export const EditingProvider: React.FC<EditingProviderProps> = ({
   isPresentationMode,
   isCollaboratorsDoc,
   isPreviewEditor,
+  isSuggestionMode,
 }) => {
   const value = useMemo(
     () => ({
@@ -47,8 +51,15 @@ export const EditingProvider: React.FC<EditingProviderProps> = ({
       isPresentationMode,
       isCollaboratorsDoc,
       isPreviewEditor,
+      isSuggestionMode,
     }),
-    [isPreviewMode, isPresentationMode, isCollaboratorsDoc, isPreviewEditor],
+    [
+      isPreviewMode,
+      isPresentationMode,
+      isCollaboratorsDoc,
+      isPreviewEditor,
+      isSuggestionMode,
+    ],
   );
   return (
     <EditingContext.Provider value={value}>{children}</EditingContext.Provider>

--- a/package/hooks/use-tab-editor.tsx
+++ b/package/hooks/use-tab-editor.tsx
@@ -419,6 +419,20 @@ export const useTabEditor = ({
     }
   }, [editor]);
 
+  // Toggle a data attribute on the editor root so CSS can suppress the
+  // "Type / to browse options" placeholder (and others) in suggestion mode.
+  useEffect(() => {
+    if (!editor || editor.isDestroyed) return;
+    // editor.view is lazily attached — guard against accessing before mount
+    const dom = editor.view?.dom;
+    if (!dom) return;
+    if (isSuggestionMode) {
+      dom.setAttribute('data-suggestion-mode', 'true');
+    } else {
+      dom.removeAttribute('data-suggestion-mode');
+    }
+  }, [editor, isSuggestionMode]);
+
   // Fix for TableOfContents not updating in Tiptap v3
   const tocDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/package/hooks/use-tab-editor.tsx
+++ b/package/hooks/use-tab-editor.tsx
@@ -178,7 +178,6 @@ interface UseTabEditorArgs {
   theme?: ThemeKey;
   editorRef?: MutableRefObject<Editor | null>;
   initialCommentAnchors?: SerializedCommentAnchor[];
-  onNewComment?: DdocProps['onNewComment'];
 }
 
 export const useTabEditor = ({
@@ -226,7 +225,6 @@ export const useTabEditor = ({
   theme,
   editorRef,
   initialCommentAnchors,
-  onNewComment,
 }: UseTabEditorArgs) => {
   const collabEnabled = collaboration?.enabled === true;
   const connection = collabEnabled ? collaboration.connection : null;

--- a/package/hooks/use-tab-editor.tsx
+++ b/package/hooks/use-tab-editor.tsx
@@ -25,16 +25,21 @@ import SlashCommand from '../extensions/slash-command/slash-comand';
 import { EditorState, TextSelection, Plugin } from '@tiptap/pm/state';
 import customTextInputRules from '../extensions/customTextInputRules';
 import { PageBreak } from '../extensions/page-break/page-break';
-import { toUint8Array } from 'js-base64';
+import { toUint8Array, fromUint8Array } from 'js-base64';
 import { isJSONString } from '../utils/isJsonString';
 import { zoomService } from '../zoom-service';
 import { sanitizeContent } from '../utils/sanitize-content';
-import { CommentExtension as Comment } from '../extensions/comment';
+import { CommentExtension as Comment, IComment } from '../extensions/comment';
+import { CommentMutationMeta } from '../types';
 import {
   CommentAnchor,
   CommentDecorationExtension,
   triggerDecorationRebuild,
 } from '../extensions/comment/comment-decoration-plugin';
+import {
+  SuggestionTrackingExtension,
+  SuggestionReadyData,
+} from '../extensions/suggestion/suggestion-tracking-extension';
 import {
   createPageCounter,
   handleContentPrint,
@@ -137,6 +142,7 @@ interface UseTabEditorArgs {
   hasTabState?: boolean;
   versionId?: string;
   isPreviewMode?: boolean;
+  viewerMode?: DdocProps['viewerMode'];
   initialContent: DdocProps['initialContent'];
   collaboration?: CollaborationProps;
   isReady?: boolean;
@@ -175,6 +181,7 @@ interface UseTabEditorArgs {
   theme?: ThemeKey;
   editorRef?: MutableRefObject<Editor | null>;
   initialCommentAnchors?: SerializedCommentAnchor[];
+  onNewComment?: DdocProps['onNewComment'];
 }
 
 export const useTabEditor = ({
@@ -183,6 +190,7 @@ export const useTabEditor = ({
   hasTabState,
   versionId,
   isPreviewMode,
+  viewerMode,
   initialContent,
   collaboration,
   isReady,
@@ -221,6 +229,7 @@ export const useTabEditor = ({
   theme,
   editorRef,
   initialCommentAnchors,
+  onNewComment,
 }: UseTabEditorArgs) => {
   const collabEnabled = collaboration?.enabled === true;
   const connection = collabEnabled ? collaboration.connection : null;
@@ -229,6 +238,8 @@ export const useTabEditor = ({
 
   const hasAvailableModels = Boolean(activeModel && isAIAgentEnabled);
   const { tocItems, setTocItems, handleTocUpdate } = useTocState(activeTabId);
+
+  const isSuggestionMode = !!(isPreviewMode && viewerMode === 'suggest');
 
   const { extensions, commentAnchorsRef } = useEditorExtension({
     ydoc,
@@ -256,6 +267,8 @@ export const useTabEditor = ({
     externalExtensions,
     activeTabId,
     initialCommentAnchors,
+    isSuggestionMode,
+    onNewComment,
   });
 
   const { handleCommentInteraction, handleCommentClick } =
@@ -445,12 +458,13 @@ export const useTabEditor = ({
   // updates into the ydoc).  All other collab states (connecting, ready,
   // reconnecting, terminating) keep the editor editable so there is no
   // scroll-jump on start or flicker on stop.
+
   const readyState = useMemo(() => {
-    if (isPreviewMode) return false;
+    if (isPreviewMode && !isSuggestionMode) return false;
     if (!isCollaborationEnabled) return true;
     if (isSyncing) return false;
     return true;
-  }, [isPreviewMode, isCollaborationEnabled, isSyncing]);
+  }, [isPreviewMode, isSuggestionMode, isCollaborationEnabled, isSyncing]);
 
   useEffect(() => {
     editor?.setEditable(readyState);
@@ -1135,6 +1149,8 @@ interface UseExtensionStackArgs {
   externalExtensions?: Record<string, AnyExtension>;
   activeTabId: string;
   initialCommentAnchors?: SerializedCommentAnchor[];
+  isSuggestionMode?: boolean;
+  onNewComment?: DdocProps['onNewComment'];
 }
 
 const useEditorExtension = ({
@@ -1158,6 +1174,8 @@ const useEditorExtension = ({
   externalExtensions,
   activeTabId,
   initialCommentAnchors,
+  isSuggestionMode = false,
+  onNewComment,
 }: UseExtensionStackArgs) => {
   const slashCommandConfigRef = useRef({
     isConnected,
@@ -1199,6 +1217,58 @@ const useEditorExtension = ({
     activeCommentIdRef.current = activeCommentId;
   }, [activeCommentId]);
 
+  // Keep a stable ref to isSuggestionMode so the extension closure always
+  // reads the latest value without needing to rebuild extensions.
+  const isSuggestionModeRef = useRef(isSuggestionMode);
+  isSuggestionModeRef.current = isSuggestionMode;
+
+  // Keep a stable ref to onNewComment so the callback always reads the latest
+  // version without needing extension rebuilds.
+  const onNewCommentRef = useRef(onNewComment);
+  onNewCommentRef.current = onNewComment;
+
+  // Called on every keystroke — upserts the live anchor so the decoration
+  // rebuilds immediately while the user is still typing.
+  const onLiveSuggestionRef = useRef<((anchor: CommentAnchor) => void) | null>(null);
+  onLiveSuggestionRef.current = (anchor: CommentAnchor) => {
+    commentAnchorsRef.current = [
+      ...commentAnchorsRef.current.filter((a) => a.id !== anchor.id),
+      anchor,
+    ];
+  };
+
+  // Called once when typing stops (cursor moves away / blur) — only for
+  // persistence. The anchor is already in commentAnchorsRef at this point.
+  const onSuggestionReadyRef = useRef<((data: SuggestionReadyData) => void) | null>(null);
+  onSuggestionReadyRef.current = (data: SuggestionReadyData) => {
+    if (!onNewCommentRef.current) return;
+
+    const newComment: IComment = {
+      id: data.suggestionId,
+      tabId: activeTabId,
+      selectedContent: data.originalContent,
+      content: '',
+      isSuggestion: true,
+      suggestionType: data.suggestionType,
+      originalContent: data.originalContent,
+      suggestedContent: data.suggestedContent,
+      resolved: false,
+      deleted: false,
+      createdAt: new Date(),
+    };
+
+    const meta: CommentMutationMeta = {
+      type: 'create',
+      anchorFrom: fromUint8Array(Y.encodeRelativePosition(data.anchorFrom)),
+      anchorTo: fromUint8Array(Y.encodeRelativePosition(data.anchorTo)),
+      suggestionType: data.suggestionType,
+      originalContent: data.originalContent,
+      suggestedContent: data.suggestedContent,
+    };
+
+    onNewCommentRef.current(newComment, meta);
+  };
+
   const commentExtension = useMemo(
     () =>
       Comment.configure({
@@ -1232,6 +1302,11 @@ const useEditorExtension = ({
       CommentDecorationExtension.configure({
         getAnchors: () => commentAnchorsRef.current,
         getActiveCommentId: () => activeCommentIdRef.current,
+      }),
+      SuggestionTrackingExtension.configure({
+        getIsSuggestionMode: () => isSuggestionModeRef.current,
+        onLiveSuggestion: (anchor) => onLiveSuggestionRef.current?.(anchor),
+        onSuggestionReady: (data) => onSuggestionReadyRef.current?.(data),
       }),
       ...(externalExtensions ? Object.values(externalExtensions) : []),
     ];

--- a/package/hooks/use-tab-editor.tsx
+++ b/package/hooks/use-tab-editor.tsx
@@ -1291,6 +1291,14 @@ const useEditorExtension = ({
         },
         onDeleteSelection: (from, to) =>
           storeApiRef.current?.getState().startDeleteDraft(from, to),
+        onDeleteAtCursor: (direction) =>
+          storeApiRef.current
+            ?.getState()
+            .deleteAtCursorOrUndoActiveDraft(direction),
+        onDeleteRangeWithoutSelection: (from, to) =>
+          storeApiRef.current
+            ?.getState()
+            .deleteRangeOrUndoActiveDraft(from, to),
         onUndo: () =>
           storeApiRef.current?.getState().undoLastKeystrokeInActiveDraft(),
       }),

--- a/package/hooks/use-tab-editor.tsx
+++ b/package/hooks/use-tab-editor.tsx
@@ -236,34 +236,35 @@ export const useTabEditor = ({
 
   const isSuggestionMode = !!(isPreviewMode && viewerMode === 'suggest');
 
-  const { extensions, commentAnchorsRef, draftAnchorsRef, storeApiRef } = useEditorExtension({
-    ydoc,
-    onError,
-    ipfsImageUploadFn,
-    metadataProxyUrl,
-    onCopyHeadingLink,
-    ipfsImageFetchFn,
-    fetchV1ImageFn,
-    enableCollaboration: collabEnabled,
-    disableInlineComment,
-    isConnected,
-    activeModel,
-    maxTokens,
-    isAIAgentEnabled,
-    hasAvailableModels,
-    activeCommentId,
-    onCommentActivated: (commentId) => {
-      setActiveCommentId(commentId || null);
-      if (commentId) {
-        setTimeout(() => focusCommentWithActiveId(commentId));
-      }
-    },
-    onTocUpdate: handleTocUpdate,
-    externalExtensions,
-    activeTabId,
-    initialCommentAnchors,
-    isSuggestionMode,
-  });
+  const { extensions, commentAnchorsRef, draftAnchorsRef, storeApiRef } =
+    useEditorExtension({
+      ydoc,
+      onError,
+      ipfsImageUploadFn,
+      metadataProxyUrl,
+      onCopyHeadingLink,
+      ipfsImageFetchFn,
+      fetchV1ImageFn,
+      enableCollaboration: collabEnabled,
+      disableInlineComment,
+      isConnected,
+      activeModel,
+      maxTokens,
+      isAIAgentEnabled,
+      hasAvailableModels,
+      activeCommentId,
+      onCommentActivated: (commentId) => {
+        setActiveCommentId(commentId || null);
+        if (commentId) {
+          setTimeout(() => focusCommentWithActiveId(commentId));
+        }
+      },
+      onTocUpdate: handleTocUpdate,
+      externalExtensions,
+      activeTabId,
+      initialCommentAnchors,
+      isSuggestionMode,
+    });
 
   const { handleCommentInteraction, handleCommentClick } =
     useCommentInteraction({
@@ -1292,6 +1293,8 @@ const useEditorExtension = ({
         },
         onDeleteSelection: (from, to) =>
           storeApiRef.current?.getState().startDeleteDraft(from, to),
+        onPasteLink: (from, to, href) =>
+          storeApiRef.current?.getState().startLinkDraft(from, to, href),
         onDeleteAtCursor: (direction) =>
           storeApiRef.current
             ?.getState()

--- a/package/hooks/use-tab-editor.tsx
+++ b/package/hooks/use-tab-editor.tsx
@@ -241,7 +241,7 @@ export const useTabEditor = ({
 
   const isSuggestionMode = !!(isPreviewMode && viewerMode === 'suggest');
 
-  const { extensions, commentAnchorsRef } = useEditorExtension({
+  const { extensions, commentAnchorsRef, draftAnchorsRef } = useEditorExtension({
     ydoc,
     onError,
     ipfsImageUploadFn,
@@ -1039,6 +1039,7 @@ export const useTabEditor = ({
     focusCommentWithActiveId,
     isContentLoading,
     commentAnchorsRef,
+    draftAnchorsRef,
   };
 };
 
@@ -1211,6 +1212,10 @@ const useEditorExtension = ({
   // Seed persisted anchors before editor creation so the decoration plugin can
   // render the initial highlight set on first paint.
   const commentAnchorsRef = useRef<CommentAnchor[]>(initialCommentAnchorState);
+  // Derived anchors for in-progress suggestion drafts. Maintained by the
+  // store's draft actions — decoration layer reads this alongside
+  // commentAnchorsRef so drafts and submitted suggestions render identically.
+  const draftAnchorsRef = useRef<CommentAnchor[]>([]);
   const activeCommentIdRef = useRef<string | null>(activeCommentId);
 
   useEffect(() => {
@@ -1300,7 +1305,10 @@ const useEditorExtension = ({
         field: activeTabId,
       }),
       CommentDecorationExtension.configure({
-        getAnchors: () => commentAnchorsRef.current,
+        getAnchors: () => [
+          ...commentAnchorsRef.current,
+          ...draftAnchorsRef.current,
+        ],
         getActiveCommentId: () => activeCommentIdRef.current,
       }),
       SuggestionTrackingExtension.configure({
@@ -1362,7 +1370,7 @@ const useEditorExtension = ({
     ]);
   }, [activeModel, maxTokens, isAIAgentEnabled, createSlashCommand]);
 
-  return { extensions, setExtensions, commentAnchorsRef };
+  return { extensions, setExtensions, commentAnchorsRef, draftAnchorsRef };
 };
 
 interface UseCommentInteractionArgs {

--- a/package/hooks/use-tab-editor.tsx
+++ b/package/hooks/use-tab-editor.tsx
@@ -271,6 +271,47 @@ export const useTabEditor = ({
       isFocusMode,
       onCommentInteraction,
     });
+  const isFocusModeRef = useRef(isFocusMode);
+
+  useEffect(() => {
+    isFocusModeRef.current = isFocusMode;
+  }, [isFocusMode]);
+
+  const focusSubmittedSuggestionFromEditorEvent = useCallback(
+    (view: EditorView, event: Event) => {
+      if (isFocusModeRef.current) {
+        return false;
+      }
+
+      const target = getInlineCommentEventTarget(event.target);
+      const suggestionNode = target?.closest<HTMLElement>(
+        '[data-suggestion-id][data-comment-id]',
+      );
+      const commentId =
+        suggestionNode?.dataset.commentId ??
+        suggestionNode?.dataset.suggestionId ??
+        null;
+
+      if (!commentId) {
+        return false;
+      }
+
+      const didFocus =
+        storeApiRef.current
+          ?.getState()
+          .focusSubmittedSuggestionFromEditor(commentId) ?? false;
+
+      if (!didFocus) {
+        return false;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      view.dom.blur();
+      return true;
+    },
+    [storeApiRef],
+  );
   const isInitialEditorCreation = useRef(true);
   const [slides, setSlides] = useState<string[]>([]);
   const memoizedExtensions = useMemo(() => extensions, [extensions]);
@@ -289,6 +330,8 @@ export const useTabEditor = ({
         },
         ...DdocEditorProps,
         handleDOMEvents: {
+          mousedown: focusSubmittedSuggestionFromEditorEvent,
+          click: focusSubmittedSuggestionFromEditorEvent,
           mouseover: handleCommentInteraction,
           keydown: (_view, event) => {
             // prevent default event listeners from firing when slash command is active

--- a/package/hooks/use-tab-editor.tsx
+++ b/package/hooks/use-tab-editor.tsx
@@ -25,21 +25,18 @@ import SlashCommand from '../extensions/slash-command/slash-comand';
 import { EditorState, TextSelection, Plugin } from '@tiptap/pm/state';
 import customTextInputRules from '../extensions/customTextInputRules';
 import { PageBreak } from '../extensions/page-break/page-break';
-import { toUint8Array, fromUint8Array } from 'js-base64';
+import { toUint8Array } from 'js-base64';
 import { isJSONString } from '../utils/isJsonString';
 import { zoomService } from '../zoom-service';
 import { sanitizeContent } from '../utils/sanitize-content';
-import { CommentExtension as Comment, IComment } from '../extensions/comment';
-import { CommentMutationMeta } from '../types';
+import { CommentExtension as Comment } from '../extensions/comment';
 import {
   CommentAnchor,
   CommentDecorationExtension,
   triggerDecorationRebuild,
 } from '../extensions/comment/comment-decoration-plugin';
-import {
-  SuggestionTrackingExtension,
-  SuggestionReadyData,
-} from '../extensions/suggestion/suggestion-tracking-extension';
+import { SuggestionTrackingExtension } from '../extensions/suggestion/suggestion-tracking-extension';
+import type { createCommentStore } from '../stores/comment-store';
 import {
   createPageCounter,
   handleContentPrint,
@@ -241,7 +238,7 @@ export const useTabEditor = ({
 
   const isSuggestionMode = !!(isPreviewMode && viewerMode === 'suggest');
 
-  const { extensions, commentAnchorsRef, draftAnchorsRef } = useEditorExtension({
+  const { extensions, commentAnchorsRef, draftAnchorsRef, storeApiRef } = useEditorExtension({
     ydoc,
     onError,
     ipfsImageUploadFn,
@@ -268,7 +265,6 @@ export const useTabEditor = ({
     activeTabId,
     initialCommentAnchors,
     isSuggestionMode,
-    onNewComment,
   });
 
   const { handleCommentInteraction, handleCommentClick } =
@@ -1040,6 +1036,7 @@ export const useTabEditor = ({
     isContentLoading,
     commentAnchorsRef,
     draftAnchorsRef,
+    storeApiRef,
   };
 };
 
@@ -1151,7 +1148,6 @@ interface UseExtensionStackArgs {
   activeTabId: string;
   initialCommentAnchors?: SerializedCommentAnchor[];
   isSuggestionMode?: boolean;
-  onNewComment?: DdocProps['onNewComment'];
 }
 
 const useEditorExtension = ({
@@ -1176,7 +1172,6 @@ const useEditorExtension = ({
   activeTabId,
   initialCommentAnchors,
   isSuggestionMode = false,
-  onNewComment,
 }: UseExtensionStackArgs) => {
   const slashCommandConfigRef = useRef({
     isConnected,
@@ -1227,52 +1222,13 @@ const useEditorExtension = ({
   const isSuggestionModeRef = useRef(isSuggestionMode);
   isSuggestionModeRef.current = isSuggestionMode;
 
-  // Keep a stable ref to onNewComment so the callback always reads the latest
-  // version without needing extension rebuilds.
-  const onNewCommentRef = useRef(onNewComment);
-  onNewCommentRef.current = onNewComment;
-
-  // Called on every keystroke — upserts the live anchor so the decoration
-  // rebuilds immediately while the user is still typing.
-  const onLiveSuggestionRef = useRef<((anchor: CommentAnchor) => void) | null>(null);
-  onLiveSuggestionRef.current = (anchor: CommentAnchor) => {
-    commentAnchorsRef.current = [
-      ...commentAnchorsRef.current.filter((a) => a.id !== anchor.id),
-      anchor,
-    ];
-  };
-
-  // Called once when typing stops (cursor moves away / blur) — only for
-  // persistence. The anchor is already in commentAnchorsRef at this point.
-  const onSuggestionReadyRef = useRef<((data: SuggestionReadyData) => void) | null>(null);
-  onSuggestionReadyRef.current = (data: SuggestionReadyData) => {
-    if (!onNewCommentRef.current) return;
-
-    const newComment: IComment = {
-      id: data.suggestionId,
-      tabId: activeTabId,
-      selectedContent: data.originalContent,
-      content: '',
-      isSuggestion: true,
-      suggestionType: data.suggestionType,
-      originalContent: data.originalContent,
-      suggestedContent: data.suggestedContent,
-      resolved: false,
-      deleted: false,
-      createdAt: new Date(),
-    };
-
-    const meta: CommentMutationMeta = {
-      type: 'create',
-      anchorFrom: fromUint8Array(Y.encodeRelativePosition(data.anchorFrom)),
-      anchorTo: fromUint8Array(Y.encodeRelativePosition(data.anchorTo)),
-      suggestionType: data.suggestionType,
-      originalContent: data.originalContent,
-      suggestedContent: data.suggestedContent,
-    };
-
-    onNewCommentRef.current(newComment, meta);
-  };
+  // Stable ref to the Zustand store API. The CommentStoreProvider populates
+  // this once it creates the store; the SuggestionTrackingExtension reads it
+  // lazily inside its event handlers so draft actions route to the store
+  // without rebuilding the editor.
+  const storeApiRef = useRef<ReturnType<typeof createCommentStore> | null>(
+    null,
+  );
 
   const commentExtension = useMemo(
     () =>
@@ -1313,8 +1269,18 @@ const useEditorExtension = ({
       }),
       SuggestionTrackingExtension.configure({
         getIsSuggestionMode: () => isSuggestionModeRef.current,
-        onLiveSuggestion: (anchor) => onLiveSuggestionRef.current?.(anchor),
-        onSuggestionReady: (data) => onSuggestionReadyRef.current?.(data),
+        onTextInput: (text) =>
+          storeApiRef.current?.getState().appendToDraftAtCursor(text),
+        onReplaceTyping: (from, to, text) => {
+          const state = storeApiRef.current?.getState();
+          if (!state) return;
+          state.startDeleteDraft(from, to);
+          state.appendToDraftAtCursor(text);
+        },
+        onDeleteSelection: (from, to) =>
+          storeApiRef.current?.getState().startDeleteDraft(from, to),
+        onUndo: () =>
+          storeApiRef.current?.getState().undoLastKeystrokeInActiveDraft(),
       }),
       ...(externalExtensions ? Object.values(externalExtensions) : []),
     ];
@@ -1370,7 +1336,13 @@ const useEditorExtension = ({
     ]);
   }, [activeModel, maxTokens, isAIAgentEnabled, createSlashCommand]);
 
-  return { extensions, setExtensions, commentAnchorsRef, draftAnchorsRef };
+  return {
+    extensions,
+    setExtensions,
+    commentAnchorsRef,
+    draftAnchorsRef,
+    storeApiRef,
+  };
 };
 
 interface UseCommentInteractionArgs {

--- a/package/hooks/use-yjs-setup.ts
+++ b/package/hooks/use-yjs-setup.ts
@@ -87,6 +87,19 @@ export const useYjsSetup = ({
     null,
   );
 
+  // Stable ref to onChange so the ydoc handler closure (and any pending
+  // debounce) keep working when onChange's identity changes between renders.
+  // Without this, the useEffect below re-subscribes on every onChange change,
+  // and the cleanup clears any pending debounce — meaning a ydoc update
+  // followed by a parent re-render within 300ms silently loses its onChange
+  // call. (Specifically observed when accepting a suggestion: the consumer's
+  // handleResolveComment writes to Dexie within the debounce window, which
+  // triggers liveQuery re-renders that recreate onChange's identity.)
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
   // Immediately flush any pending debounced onChange.
   // Call this after critical structural changes (tab create/delete/rename/reorder)
   // to ensure persistence happens before a potential page refresh.
@@ -95,8 +108,8 @@ export const useYjsSetup = ({
       clearTimeout(onChangeDebounceRef.current);
       onChangeDebounceRef.current = null;
     }
-    onChange?.(fromUint8Array(Y.encodeStateAsUpdate(ydoc)), '');
-  }, [ydoc, onChange]);
+    onChangeRef.current?.(fromUint8Array(Y.encodeStateAsUpdate(ydoc)), '');
+  }, [ydoc]);
 
   useEffect(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -114,7 +127,10 @@ export const useYjsSetup = ({
       }
       onChangeDebounceRef.current = setTimeout(() => {
         onChangeDebounceRef.current = null;
-        onChange?.(fromUint8Array(Y.encodeStateAsUpdate(ydoc)), chunk);
+        onChangeRef.current?.(
+          fromUint8Array(Y.encodeStateAsUpdate(ydoc)),
+          chunk,
+        );
       }, 300);
     };
     if (ydoc) {
@@ -122,11 +138,11 @@ export const useYjsSetup = ({
     }
     return () => {
       ydoc?.off('update', handler);
-      if (onChangeDebounceRef.current) {
-        clearTimeout(onChangeDebounceRef.current);
-      }
+      // Intentionally do NOT clear the pending debounce here. The ref-based
+      // handler is stable, so re-runs of this effect (which only happen on
+      // ydoc change — never in practice) shouldn't cancel in-flight saves.
     };
-  }, [onChange, ydoc]);
+  }, [ydoc]);
 
   return {
     ydoc,

--- a/package/stores/comment-store-provider.tsx
+++ b/package/stores/comment-store-provider.tsx
@@ -65,6 +65,12 @@ export interface CommentStoreProviderProps {
   ensResolutionUrl: string;
   commentAnchorsRef?: React.MutableRefObject<CommentAnchor[]>;
   draftAnchorsRef?: React.MutableRefObject<CommentAnchor[]>;
+  /**
+   * Ref populated by the provider with the Zustand store instance.
+   * SuggestionTrackingExtension reads this inside event handlers to route
+   * keystrokes into draft actions without rebuilding the editor.
+   */
+  storeApiRef?: React.MutableRefObject<ReturnType<typeof createCommentStore> | null>;
   initialCommentAnchors?: SerializedCommentAnchor[];
   // Synced data — go into store via useEffect
   initialComments: IComment[];
@@ -101,6 +107,7 @@ export const CommentStoreProvider = ({
   ensResolutionUrl,
   commentAnchorsRef,
   draftAnchorsRef,
+  storeApiRef,
   initialCommentAnchors,
   setUsername: setUsernameProp,
   // Synced data (useEffect-based)
@@ -270,6 +277,20 @@ export const CommentStoreProvider = ({
   useEffect(() => {
     store.getState().setExternalDepsRef(externalDepsRef);
   }, [store]);
+
+  // Publish the store instance to the SuggestionTrackingExtension via the
+  // caller-provided ref. The extension reads this ref lazily on every
+  // keystroke, so as long as it's populated before the viewer types, drafts
+  // route correctly.
+  useEffect(() => {
+    if (!storeApiRef) return;
+    storeApiRef.current = store;
+    return () => {
+      if (storeApiRef.current === store) {
+        storeApiRef.current = null;
+      }
+    };
+  }, [store, storeApiRef]);
 
   // --- Sync data props into store (only when values change) ---
   useEffect(() => {

--- a/package/stores/comment-store-provider.tsx
+++ b/package/stores/comment-store-provider.tsx
@@ -346,17 +346,37 @@ export const CommentStoreProvider = ({
   // this happens when the owner deletes the surrounding text while a viewer
   // has an in-progress draft anchored to it. Per the spec, the draft is
   // lost with no warning.
+  //
+  // Also refreshes `originalContent` on Delete/Replace drafts whose anchor
+  // still resolves but now covers different text (owner edited inside the
+  // anchored range), so the draft card's diff summary stays accurate.
   useEffect(() => {
     if (!editor) return;
     const handler = ({ transaction }: { transaction: Transaction }) => {
       if (!transaction.docChanged) return;
       const state = store.getState();
       for (const draft of Object.values(state.drafts)) {
-        const resolved = draft.hadDeletion
-          ? resolveCommentAnchorRangeInState(draft, editor.state)
-          : resolveCommentAnchorPointInState(draft, editor.state);
-        if (resolved === null) {
+        if (!draft.hadDeletion) {
+          const point = resolveCommentAnchorPointInState(draft, editor.state);
+          if (point === null) {
+            state.discardDraft(draft.id);
+          }
+          continue;
+        }
+
+        const range = resolveCommentAnchorRangeInState(draft, editor.state);
+        if (range === null) {
           state.discardDraft(draft.id);
+          continue;
+        }
+
+        const currentText = editor.state.doc.textBetween(
+          range.from,
+          range.to,
+          '\n',
+        );
+        if (currentText !== draft.originalContent) {
+          state.refreshDraftOriginalContent(draft.id, currentText);
         }
       }
     };

--- a/package/stores/comment-store-provider.tsx
+++ b/package/stores/comment-store-provider.tsx
@@ -17,6 +17,8 @@ import {
   CommentAnchor,
   type CommentAnchorTransactionChange,
   getCommentAtPosition,
+  resolveCommentAnchorPointInState,
+  resolveCommentAnchorRangeInState,
   triggerDecorationRebuild,
   resolveCommentAnchorRangeInState,
   resolveCommentAnchorRangeForAnalysis,
@@ -291,6 +293,30 @@ export const CommentStoreProvider = ({
       }
     };
   }, [store, storeApiRef]);
+
+  // Silently discard drafts whose Yjs anchors can no longer be resolved —
+  // this happens when the owner deletes the surrounding text while a viewer
+  // has an in-progress draft anchored to it. Per the spec, the draft is
+  // lost with no warning.
+  useEffect(() => {
+    if (!editor) return;
+    const handler = ({ transaction }: { transaction: Transaction }) => {
+      if (!transaction.docChanged) return;
+      const state = store.getState();
+      for (const draft of Object.values(state.drafts)) {
+        const resolved = draft.hadDeletion
+          ? resolveCommentAnchorRangeInState(draft, editor.state)
+          : resolveCommentAnchorPointInState(draft, editor.state);
+        if (resolved === null) {
+          state.discardDraft(draft.id);
+        }
+      }
+    };
+    editor.on('transaction', handler);
+    return () => {
+      editor.off('transaction', handler);
+    };
+  }, [editor, store]);
 
   // --- Sync data props into store (only when values change) ---
   useEffect(() => {

--- a/package/stores/comment-store-provider.tsx
+++ b/package/stores/comment-store-provider.tsx
@@ -24,6 +24,7 @@ import {
 } from '../extensions/comment/comment-decoration-plugin';
 import { CommentMutationMeta, SerializedCommentAnchor } from '../types';
 import type { CommentFloatingThreadCard } from '../components/inline-comment/context/types';
+import { DEFAULT_TAB_ID } from '../components/tabs/utils/tab-utils';
 import { useResponsive } from '../utils/responsive';
 import {
   deserializeCommentAnchors,
@@ -306,7 +307,11 @@ export const CommentStoreProvider = ({
             !c.resolved &&
             !c.deleted &&
             c.id &&
-            c.tabId === activeTabId,
+            // Match tabComments derivation: missing tabId is treated as the
+            // default tab. Without this normalization, suggestions submitted
+            // in single-tab docs (where tabId can be undefined) silently
+            // miss the auto-spawn.
+            (c.tabId || DEFAULT_TAB_ID) === activeTabId,
         ),
     );
     if (pendingSuggestions.length === 0) return;
@@ -765,6 +770,19 @@ export const CommentStoreProvider = ({
       if (transaction.docChanged) {
         const oldState = preTransactionStateRef.current;
         preTransactionStateRef.current = null;
+
+        // Suggestion mode (and any other extension that returns false from
+        // filterTransaction) cancels the transaction before it's applied.
+        // The TipTap 'transaction' event still fires with the *attempted*
+        // transform, so without this guard the anchor-deletion analysis
+        // sees the would-be deletion and prunes the anchor — wiping a
+        // working inline comment when the viewer types over it in
+        // suggest mode. If the editor state's doc didn't actually move,
+        // the transaction was filtered; nothing to analyze.
+        if (oldState && oldState.doc === editor.state.doc) {
+          return;
+        }
+
         let shouldRebuildDecorations = false;
         let didRestoreRemovedAnchors = false;
 

--- a/package/stores/comment-store-provider.tsx
+++ b/package/stores/comment-store-provider.tsx
@@ -64,6 +64,7 @@ export interface CommentStoreProviderProps {
   connectViaUsername?: (username: string) => Promise<void>;
   ensResolutionUrl: string;
   commentAnchorsRef?: React.MutableRefObject<CommentAnchor[]>;
+  draftAnchorsRef?: React.MutableRefObject<CommentAnchor[]>;
   initialCommentAnchors?: SerializedCommentAnchor[];
   // Synced data — go into store via useEffect
   initialComments: IComment[];
@@ -99,6 +100,7 @@ export const CommentStoreProvider = ({
   connectViaUsername,
   ensResolutionUrl,
   commentAnchorsRef,
+  draftAnchorsRef,
   initialCommentAnchors,
   setUsername: setUsernameProp,
   // Synced data (useEffect-based)
@@ -235,6 +237,7 @@ export const CommentStoreProvider = ({
     ensResolutionUrl,
     commentAnchorsRef,
     refreshCommentAnchorState,
+    draftAnchorsRef,
   });
 
   // Update ref on every render — no set(), no re-render loop
@@ -260,6 +263,7 @@ export const CommentStoreProvider = ({
     ensResolutionUrl,
     commentAnchorsRef,
     refreshCommentAnchorState,
+    draftAnchorsRef,
   };
 
   // Inject ref into store once

--- a/package/stores/comment-store-provider.tsx
+++ b/package/stores/comment-store-provider.tsx
@@ -42,6 +42,17 @@ import {
   isRangeDraft,
 } from './comment-store';
 
+const hasResolvableCommentAnchorInState = (
+  anchor: CommentAnchor,
+  state: EditorState,
+) => {
+  if (anchor.isSuggestion && anchor.suggestionType === 'add') {
+    return resolveCommentAnchorPointInState(anchor, state) !== null;
+  }
+
+  return resolveCommentAnchorRangeInState(anchor, state) !== null;
+};
+
 export interface CommentStoreProviderProps {
   children: React.ReactNode;
   editor: Editor | null;
@@ -209,7 +220,7 @@ export const CommentStoreProvider = ({
             .filter(
               (anchor) =>
                 !anchor.deleted &&
-                Boolean(resolveCommentAnchorRangeInState(anchor, editor.state)),
+                hasResolvableCommentAnchorInState(anchor, editor.state),
             )
             .map((anchor) => anchor.id)
         : [];
@@ -831,14 +842,22 @@ export const CommentStoreProvider = ({
           // Analyze only active anchors that belong to the currently rendered tab.
           // `commentAnchorsRef` can contain anchors from other tabs, but this
           // transaction only mutates the active Yjs fragment. Keeping off-tab
-          // anchors out of this batch prevents tab B comments from changing tab
-          // A undo/delete decisions.
-          const activeAnchors = commentAnchorsRef.current.filter(
-            (anchor) =>
-              !anchor.deleted &&
-              !anchor.resolved &&
-              resolveCommentAnchorRangeForAnalysis(anchor, oldState) !== null,
-          );
+          // range anchors out of this batch prevents tab B comments from changing
+          // tab A undo/delete decisions. Add suggestions are point anchors, so the
+          // analyzer performs the single point-resolution pass for them.
+          const activeAnchors = commentAnchorsRef.current.filter((anchor) => {
+            if (anchor.deleted || anchor.resolved) {
+              return false;
+            }
+
+            if (anchor.isSuggestion && anchor.suggestionType === 'add') {
+              return true;
+            }
+
+            return (
+              resolveCommentAnchorRangeForAnalysis(anchor, oldState) !== null
+            );
+          });
 
           if (activeAnchors.length > 0) {
             // Combine transaction and appended steps into a single transform.

--- a/package/stores/comment-store-provider.tsx
+++ b/package/stores/comment-store-provider.tsx
@@ -24,6 +24,7 @@ import {
   resolveCommentAnchorRangeForAnalysis,
 } from '../extensions/comment/comment-decoration-plugin';
 import { CommentMutationMeta, SerializedCommentAnchor } from '../types';
+import type { CommentFloatingThreadCard } from '../components/inline-comment/context/types';
 import { useResponsive } from '../utils/responsive';
 import {
   deserializeCommentAnchors,
@@ -293,6 +294,53 @@ export const CommentStoreProvider = ({
       }
     };
   }, [store, storeApiRef]);
+
+  // Auto-spawn a floating thread card for every unresolved submitted
+  // suggestion. Regular comments open on click; suggestions are always
+  // visible per the product spec ("Suggestion should always be visible on
+  // viewer/owner mode if they are not accepted/rejected/resolved").
+  useEffect(() => {
+    const pendingSuggestions = initialComments.filter(
+      (c): c is IComment & { id: string } =>
+        Boolean(
+          c.isSuggestion &&
+            !c.resolved &&
+            !c.deleted &&
+            c.id &&
+            c.tabId === activeTabId,
+        ),
+    );
+    if (pendingSuggestions.length === 0) return;
+
+    const state = store.getState();
+    const existingThreadIds = new Set(
+      state.floatingCards
+        .filter((c): c is CommentFloatingThreadCard => c.type === 'thread')
+        .map((c) => c.commentId),
+    );
+
+    const toAdd = pendingSuggestions.filter(
+      (c) => !existingThreadIds.has(c.id),
+    );
+    if (toAdd.length === 0) return;
+
+    // Inline card creation — openFloatingThread guards on non-empty
+    // selectedContent which Add suggestions don't have.
+    store.setState((current) => ({
+      floatingCards: [
+        ...current.floatingCards,
+        ...toAdd.map(
+          (c): CommentFloatingThreadCard => ({
+            type: 'thread',
+            floatingCardId: `suggestion-thread:${c.id}`,
+            commentId: c.id,
+            selectedText: c.selectedContent ?? '',
+            isFocused: false,
+          }),
+        ),
+      ],
+    }));
+  }, [initialComments, activeTabId, store]);
 
   // Silently discard drafts whose Yjs anchors can no longer be resolved —
   // this happens when the owner deletes the surrounding text while a viewer

--- a/package/stores/comment-store-provider.tsx
+++ b/package/stores/comment-store-provider.tsx
@@ -19,9 +19,8 @@ import {
   getCommentAtPosition,
   resolveCommentAnchorPointInState,
   resolveCommentAnchorRangeInState,
-  triggerDecorationRebuild,
-  resolveCommentAnchorRangeInState,
   resolveCommentAnchorRangeForAnalysis,
+  triggerDecorationRebuild,
 } from '../extensions/comment/comment-decoration-plugin';
 import { CommentMutationMeta, SerializedCommentAnchor } from '../types';
 import type { CommentFloatingThreadCard } from '../components/inline-comment/context/types';

--- a/package/stores/comment-store-provider.tsx
+++ b/package/stores/comment-store-provider.tsx
@@ -39,6 +39,7 @@ import {
   CommentStoreContext,
   createCommentStore,
   EXPLICIT_COMMENT_FOCUS_META,
+  isRangeDraft,
 } from './comment-store';
 
 export interface CommentStoreProviderProps {
@@ -74,7 +75,9 @@ export interface CommentStoreProviderProps {
    * SuggestionTrackingExtension reads this inside event handlers to route
    * keystrokes into draft actions without rebuilding the editor.
    */
-  storeApiRef?: React.MutableRefObject<ReturnType<typeof createCommentStore> | null>;
+  storeApiRef?: React.MutableRefObject<ReturnType<
+    typeof createCommentStore
+  > | null>;
   initialCommentAnchors?: SerializedCommentAnchor[];
   // Synced data — go into store via useEffect
   initialComments: IComment[];
@@ -355,16 +358,16 @@ export const CommentStoreProvider = ({
   // has an in-progress draft anchored to it. Per the spec, the draft is
   // lost with no warning.
   //
-  // Also refreshes `originalContent` on Delete/Replace drafts whose anchor
-  // still resolves but now covers different text (owner edited inside the
-  // anchored range), so the draft card's diff summary stays accurate.
+  // Also refreshes `originalContent` on range-backed drafts whose anchor still
+  // resolves but now covers different text (owner edited inside the anchored
+  // range), so the draft card's diff summary stays accurate.
   useEffect(() => {
     if (!editor) return;
     const handler = ({ transaction }: { transaction: Transaction }) => {
       if (!transaction.docChanged) return;
       const state = store.getState();
       for (const draft of Object.values(state.drafts)) {
-        if (!draft.hadDeletion) {
+        if (!isRangeDraft(draft)) {
           const point = resolveCommentAnchorPointInState(draft, editor.state);
           if (point === null) {
             state.discardDraft(draft.id);

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -5,21 +5,27 @@ import {
   CommentAnchor,
   applyAcceptedSuggestion,
   createCommentAnchorFromEditor,
+  createCommentAnchorPointFromEditor,
+  getCommentAnchorRange,
+  resolveCommentAnchorPointInState,
   resolveCommentAnchorRangeInState,
   triggerDecorationRebuild,
 } from '../extensions/comment/comment-decoration-plugin';
+import { SuggestionType } from '../types';
 import uuid from 'react-uuid';
 import { createStore, useStore } from 'zustand';
 import { fromUint8Array } from 'js-base64';
 import * as Y from 'yjs';
-import { TextSelection } from '@tiptap/pm/state';
+import { EditorState, TextSelection } from '@tiptap/pm/state';
 import {
   CommentFloatingCard,
   CommentFloatingDraftCard,
+  CommentFloatingThreadCard,
   EnsCache,
   InlineCommentData,
   InlineCommentDraft,
   InlineDraftLocation,
+  SuggestionFloatingDraftCard,
 } from '../components/inline-comment/context/types';
 import { EnsStatus } from '../components/inline-comment/types';
 import { DEFAULT_TAB_ID } from '../components/tabs/utils/tab-utils';
@@ -57,6 +63,76 @@ export interface CommentExternalDeps {
   ensResolutionUrl: string;
   commentAnchorsRef?: React.MutableRefObject<CommentAnchor[]>;
   refreshCommentAnchorState?: () => void;
+  /**
+   * Derived anchor list for in-progress suggestion drafts. Maintained by the
+   * store (not the consumer) — draft actions upsert into this ref whenever
+   * state.drafts changes. The decoration extension reads this ref alongside
+   * commentAnchorsRef to render both layers identically.
+   */
+  draftAnchorsRef?: React.MutableRefObject<CommentAnchor[]>;
+}
+
+/**
+ * A suggestion draft is the viewer's in-progress proposed edit — kept local
+ * until Submit. Drafts live in memory only (lost on refresh). Derived into
+ * a CommentAnchor for decoration rendering via deriveDraftAnchor(). The
+ * suggestion type ('add' | 'delete' | 'replace') is not stored; it is derived
+ * at use time from hadDeletion + insertedText.
+ */
+export interface DraftSuggestion {
+  id: string;
+  anchorFrom: Y.RelativePosition;
+  anchorTo: Y.RelativePosition;
+  /** The text that was selected at draft creation (for Delete/Replace strikethrough). */
+  originalContent: string;
+  /** Accumulated text the viewer has typed. Empty for a pure Delete draft. */
+  insertedText: string;
+  /** Per-keystroke history for undo — each entry is one typed character. */
+  keystrokes: string[];
+  /** True when the draft was created via select+delete or select+type. */
+  hadDeletion: boolean;
+}
+
+function deriveDraftSuggestionType(draft: DraftSuggestion): SuggestionType {
+  if (draft.hadDeletion) {
+    return draft.insertedText.length > 0 ? 'replace' : 'delete';
+  }
+  return 'add';
+}
+
+function deriveDraftAnchor(draft: DraftSuggestion): CommentAnchor {
+  return {
+    id: draft.id,
+    anchorFrom: draft.anchorFrom,
+    anchorTo: draft.anchorTo,
+    resolved: false,
+    deleted: false,
+    isSuggestion: true,
+    suggestionType: deriveDraftSuggestionType(draft),
+    originalContent: draft.originalContent,
+    suggestedContent: draft.insertedText,
+  };
+}
+
+function findDraftAtEditorCursor(
+  drafts: Record<string, DraftSuggestion>,
+  state: EditorState,
+): DraftSuggestion | null {
+  const { from, to } = state.selection;
+  for (const draft of Object.values(drafts)) {
+    if (draft.hadDeletion) {
+      // Delete / Replace draft: cursor must be within [anchorFrom, anchorTo]
+      const range = resolveCommentAnchorRangeInState(draft, state);
+      if (!range) continue;
+      if (from >= range.from && to <= range.to) return draft;
+    } else {
+      // Add draft: point anchor — cursor must be exactly at the anchor point
+      const point = resolveCommentAnchorPointInState(draft, state);
+      if (point === null) continue;
+      if (from === to && from === point) return draft;
+    }
+  }
+  return null;
 }
 
 type FloatingCardsUpdater = React.SetStateAction<CommentFloatingCard[]>;
@@ -488,6 +564,8 @@ export interface CommentStoreState {
   // Tracks just-created floating threads that already have a local anchor but
   // have not been rehydrated into canonical comment props yet.
   pendingPrehydrationFloatingThreadIds: string[];
+  /** In-progress suggestion drafts — keyed by suggestionId. Viewer-local, lost on refresh. */
+  drafts: Record<string, DraftSuggestion>;
   inlineDrafts: InlineDraftRecordMap;
   activeDraftId: string | null;
   isDesktopFloatingEnabled: boolean;
@@ -602,6 +680,34 @@ export interface CommentStoreState {
     options?: { skipExternalCallback?: boolean },
   ) => void;
   acceptSuggestion: (commentId: string) => void;
+
+  // --- Suggestion draft operations (Phase 2 — viewer-local drafts) ---
+  /**
+   * Append typed characters to the draft at the current cursor position.
+   * Creates a new Add draft if no draft exists at the cursor.
+   */
+  appendToDraftAtCursor: (text: string) => void;
+  /**
+   * Create a Delete (or pending Replace) draft from a selection range.
+   * Captures originalContent, leaves insertedText empty; type becomes 'replace'
+   * as soon as the viewer types.
+   */
+  startDeleteDraft: (from: number, to: number) => void;
+  /**
+   * Undo the last keystroke in the draft at the current cursor position.
+   * When the draft has no keystrokes left, it is discarded.
+   * For a pure Delete draft (no keystrokes ever), calling this discards.
+   */
+  undoLastKeystrokeInActiveDraft: () => void;
+  /** Drop a draft entirely — removes the inline overlay and draft card. */
+  discardDraft: (suggestionId: string) => void;
+  /**
+   * Promote a draft to a submitted suggestion. Pushes the anchor into
+   * commentAnchorsRef, calls onNewComment, removes the draft, and swaps the
+   * suggestion-draft floating card for a thread card (same floatingCardId).
+   */
+  submitDraft: (suggestionId: string) => void;
+
   deleteReply: (commentId: string, replyId: string) => void;
   requestEditComment: (commentId: string) => void;
   requestEditReply: (commentId: string, replyId: string) => void;
@@ -674,6 +780,7 @@ export const createCommentStore = () =>
     },
     floatingCards: [],
     pendingPrehydrationFloatingThreadIds: [],
+    drafts: {},
     inlineDrafts: {},
     activeDraftId: null,
     isDesktopFloatingEnabled: false,
@@ -2117,6 +2224,256 @@ export const createCommentStore = () =>
         setActiveCommentId(null);
       }
     },
+
+    // --- Suggestion draft operations ---------------------------------------
+
+    appendToDraftAtCursor: (text) => {
+      const deps = getExtDeps(get);
+      const { editor, draftAnchorsRef } = deps;
+      if (!editor) return;
+
+      const currentDrafts = get().drafts;
+      const activeDraft = findDraftAtEditorCursor(currentDrafts, editor.state);
+
+      let nextDrafts: Record<string, DraftSuggestion>;
+      let nextCards = get().floatingCards;
+
+      if (activeDraft) {
+        const extended: DraftSuggestion = {
+          ...activeDraft,
+          insertedText: activeDraft.insertedText + text,
+          keystrokes: [...activeDraft.keystrokes, text],
+        };
+        nextDrafts = { ...currentDrafts, [activeDraft.id]: extended };
+        // Mirror the updated insertedText on the floating card for the diff preview.
+        nextCards = nextCards.map((c) =>
+          c.type === 'suggestion-draft' && c.suggestionId === activeDraft.id
+            ? { ...c, insertedText: extended.insertedText }
+            : c,
+        );
+      } else {
+        const { from } = editor.state.selection;
+        const anchorPoint = createCommentAnchorPointFromEditor(editor, from);
+        if (!anchorPoint) return;
+
+        const id = `suggestion-${uuid()}`;
+        const newDraft: DraftSuggestion = {
+          id,
+          anchorFrom: anchorPoint.anchorFrom,
+          anchorTo: anchorPoint.anchorTo,
+          originalContent: '',
+          insertedText: text,
+          keystrokes: [text],
+          hadDeletion: false,
+        };
+        nextDrafts = { ...currentDrafts, [id]: newDraft };
+
+        const newCard: SuggestionFloatingDraftCard = {
+          type: 'suggestion-draft',
+          floatingCardId: `suggestion-draft:${id}`,
+          suggestionId: id,
+          selectedText: '',
+          insertedText: text,
+          isFocused: true,
+        };
+        nextCards = [
+          ...nextCards.map((c) => ({ ...c, isFocused: false })),
+          newCard,
+        ];
+      }
+
+      set({ drafts: nextDrafts, floatingCards: nextCards });
+      if (draftAnchorsRef) {
+        draftAnchorsRef.current =
+          Object.values(nextDrafts).map(deriveDraftAnchor);
+      }
+      triggerDecorationRebuild(editor);
+    },
+
+    startDeleteDraft: (from, to) => {
+      const deps = getExtDeps(get);
+      const { editor, draftAnchorsRef } = deps;
+      if (!editor) return;
+      if (from >= to) return;
+
+      const anchorRange = createCommentAnchorFromEditor(editor, from, to);
+      if (!anchorRange) return;
+
+      const originalContent = editor.state.doc.textBetween(from, to, '\n');
+
+      const id = `suggestion-${uuid()}`;
+      const newDraft: DraftSuggestion = {
+        id,
+        anchorFrom: anchorRange.anchorFrom,
+        anchorTo: anchorRange.anchorTo,
+        originalContent,
+        insertedText: '',
+        keystrokes: [],
+        hadDeletion: true,
+      };
+
+      const newCard: SuggestionFloatingDraftCard = {
+        type: 'suggestion-draft',
+        floatingCardId: `suggestion-draft:${id}`,
+        suggestionId: id,
+        selectedText: originalContent,
+        insertedText: '',
+        isFocused: true,
+      };
+
+      const nextDrafts = { ...get().drafts, [id]: newDraft };
+      const nextCards = [
+        ...get().floatingCards.map((c) => ({ ...c, isFocused: false })),
+        newCard,
+      ];
+
+      set({ drafts: nextDrafts, floatingCards: nextCards });
+      if (draftAnchorsRef) {
+        draftAnchorsRef.current =
+          Object.values(nextDrafts).map(deriveDraftAnchor);
+      }
+
+      // Collapse the selection to `to` so the caret renders at the end of the
+      // strikethrough, matching Google Docs behavior.
+      const tr = editor.state.tr.setSelection(
+        TextSelection.near(editor.state.doc.resolve(to)),
+      );
+      editor.view.dispatch(tr);
+
+      triggerDecorationRebuild(editor);
+    },
+
+    undoLastKeystrokeInActiveDraft: () => {
+      const deps = getExtDeps(get);
+      const { editor, draftAnchorsRef } = deps;
+      if (!editor) return;
+
+      const activeDraft = findDraftAtEditorCursor(get().drafts, editor.state);
+      if (!activeDraft) return;
+
+      const nextKeystrokes = activeDraft.keystrokes.slice(0, -1);
+      const nextInsertedText = nextKeystrokes.join('');
+
+      // When no keystrokes remain (pure Add / Replace undone to empty, or
+      // pure Delete with no keystrokes ever), discard the draft.
+      if (nextKeystrokes.length === 0) {
+        get().discardDraft(activeDraft.id);
+        return;
+      }
+
+      const updated: DraftSuggestion = {
+        ...activeDraft,
+        keystrokes: nextKeystrokes,
+        insertedText: nextInsertedText,
+      };
+      const nextDrafts = { ...get().drafts, [activeDraft.id]: updated };
+      const nextCards = get().floatingCards.map((c) =>
+        c.type === 'suggestion-draft' && c.suggestionId === activeDraft.id
+          ? { ...c, insertedText: nextInsertedText }
+          : c,
+      );
+
+      set({ drafts: nextDrafts, floatingCards: nextCards });
+      if (draftAnchorsRef) {
+        draftAnchorsRef.current =
+          Object.values(nextDrafts).map(deriveDraftAnchor);
+      }
+      triggerDecorationRebuild(editor);
+    },
+
+    discardDraft: (suggestionId) => {
+      const deps = getExtDeps(get);
+      const { editor, draftAnchorsRef } = deps;
+
+      const currentDrafts = get().drafts;
+      if (!currentDrafts[suggestionId]) return;
+
+      const nextDrafts = { ...currentDrafts };
+      delete nextDrafts[suggestionId];
+
+      const nextCards = get().floatingCards.filter(
+        (c) => !(c.type === 'suggestion-draft' && c.suggestionId === suggestionId),
+      );
+
+      set({ drafts: nextDrafts, floatingCards: nextCards });
+      if (draftAnchorsRef) {
+        draftAnchorsRef.current =
+          Object.values(nextDrafts).map(deriveDraftAnchor);
+      }
+      if (editor) triggerDecorationRebuild(editor);
+    },
+
+    submitDraft: (suggestionId) => {
+      const deps = getExtDeps(get);
+      const { editor, commentAnchorsRef, draftAnchorsRef, onNewComment } = deps;
+      if (!editor || !commentAnchorsRef) return;
+
+      const draft = get().drafts[suggestionId];
+      if (!draft) return;
+
+      const suggestionType = deriveDraftSuggestionType(draft);
+
+      // Promote draft anchor into commentAnchorsRef so the decoration layer
+      // reads it from the "submitted" source henceforth.
+      const submittedAnchor: CommentAnchor = deriveDraftAnchor(draft);
+      commentAnchorsRef.current = [
+        ...commentAnchorsRef.current,
+        submittedAnchor,
+      ];
+
+      // Remove from drafts and swap the floating card — same floatingCardId so
+      // the card stays in place and the contents transition without remounting.
+      const nextDrafts = { ...get().drafts };
+      delete nextDrafts[suggestionId];
+
+      const nextCards = get().floatingCards.map((c) => {
+        if (c.type !== 'suggestion-draft' || c.suggestionId !== suggestionId) {
+          return c;
+        }
+        const threadCard: CommentFloatingThreadCard = {
+          type: 'thread',
+          floatingCardId: c.floatingCardId,
+          commentId: draft.id,
+          selectedText: draft.originalContent,
+          isFocused: c.isFocused,
+        };
+        return threadCard;
+      });
+
+      set({ drafts: nextDrafts, floatingCards: nextCards });
+      if (draftAnchorsRef) {
+        draftAnchorsRef.current =
+          Object.values(nextDrafts).map(deriveDraftAnchor);
+      }
+      triggerDecorationRebuild(editor);
+
+      // Build IComment + meta and hand off to the consumer pipeline.
+      const newComment: IComment = {
+        id: draft.id,
+        tabId: get().activeTabId,
+        selectedContent: draft.originalContent,
+        content: '',
+        isSuggestion: true,
+        suggestionType,
+        originalContent: draft.originalContent,
+        suggestedContent: draft.insertedText,
+        resolved: false,
+        deleted: false,
+        createdAt: new Date(),
+      };
+
+      const meta: CommentMutationMeta = {
+        type: 'create',
+        anchorFrom: fromUint8Array(Y.encodeRelativePosition(draft.anchorFrom)),
+        anchorTo: fromUint8Array(Y.encodeRelativePosition(draft.anchorTo)),
+        suggestionType,
+        originalContent: draft.originalContent,
+        suggestedContent: draft.insertedText,
+      };
+
+      onNewComment?.(newComment, meta);
+    },
+
     deleteReply: (commentId, replyId) => {
       getExtDeps(get).setInitialComments?.((previousComments) =>
         previousComments.map((comment) => {

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -566,6 +566,12 @@ export interface CommentStoreState {
   pendingPrehydrationFloatingThreadIds: string[];
   /** In-progress suggestion drafts — keyed by suggestionId. Viewer-local, lost on refresh. */
   drafts: Record<string, DraftSuggestion>;
+  /**
+   * Suggestion IDs submitted from this session. Used to show the withdraw (X)
+   * action for viewers even when they don't have a persistent username set.
+   * Session-local, lost on refresh.
+   */
+  mySubmittedSuggestionIds: Set<string>;
   inlineDrafts: InlineDraftRecordMap;
   activeDraftId: string | null;
   isDesktopFloatingEnabled: boolean;
@@ -781,6 +787,7 @@ export const createCommentStore = () =>
     floatingCards: [],
     pendingPrehydrationFloatingThreadIds: [],
     drafts: {},
+    mySubmittedSuggestionIds: new Set<string>(),
     inlineDrafts: {},
     activeDraftId: null,
     isDesktopFloatingEnabled: false,
@@ -829,7 +836,32 @@ export const createCommentStore = () =>
 
     // --- Synced data setters (batch with derived recomputation to avoid double set) ---
     setInitialComments: (comments) => {
-      set({ initialComments: comments });
+      // Consumers persist comments through a cache schema that does not yet
+      // store suggestion metadata (isSuggestion, suggestionType, originalContent,
+      // suggestedContent). When the cache round-trips a suggestion back through
+      // setInitialComments, those fields would be lost, flipping the UI from
+      // SuggestionThreadFloatingCard to the generic ThreadFloatingCard. Merge
+      // the local suggestion metadata back in for comments we already know are
+      // suggestions in the current store.
+      const previousById = new Map(
+        get().initialComments.map((comment) => [comment.id, comment]),
+      );
+      const merged = comments.map((comment) => {
+        const previous = comment.id ? previousById.get(comment.id) : undefined;
+        if (!previous?.isSuggestion) {
+          return comment;
+        }
+        return {
+          ...comment,
+          isSuggestion: true,
+          suggestionType: comment.suggestionType ?? previous.suggestionType,
+          originalContent: comment.originalContent ?? previous.originalContent,
+          suggestedContent:
+            comment.suggestedContent ?? previous.suggestedContent,
+        };
+      });
+
+      set({ initialComments: merged });
       // Recompute in same tick — Zustand batches synchronous set() calls
       const {
         activeTabId,
@@ -837,7 +869,7 @@ export const createCommentStore = () =>
         openReplyId,
         pendingPrehydrationFloatingThreadIds,
       } = get();
-      const tabComments = comments.filter(
+      const tabComments = merged.filter(
         (comment) => (comment.tabId || DEFAULT_TAB_ID) === activeTabId,
       );
       const activeComments = tabComments.filter(
@@ -855,7 +887,7 @@ export const createCommentStore = () =>
       // `openReplyId` drives the mobile focused-thread mode. Only deleted
       // comments should clear it here; resolved comments must retain focus so
       // the drawer stays in the active thread view.
-      const nextOpenReplyId = comments.some(
+      const nextOpenReplyId = merged.some(
         (comment) => comment.id === openReplyId && !comment.deleted,
       )
         ? openReplyId
@@ -1558,7 +1590,13 @@ export const createCommentStore = () =>
           comment.id === commentId && !comment.deleted && !comment.resolved,
       );
 
-      if (!editor || !commentToOpen?.selectedContent) {
+      if (!editor || !commentToOpen) {
+        return;
+      }
+
+      // Add suggestions have empty selectedContent (point anchor), so the old
+      // `!commentToOpen.selectedContent` guard would incorrectly bail out here.
+      if (!commentToOpen.isSuggestion && !commentToOpen.selectedContent) {
         return;
       }
 
@@ -2440,19 +2478,16 @@ export const createCommentStore = () =>
         return threadCard;
       });
 
-      set({ drafts: nextDrafts, floatingCards: nextCards });
-      if (draftAnchorsRef) {
-        draftAnchorsRef.current =
-          Object.values(nextDrafts).map(deriveDraftAnchor);
-      }
-      triggerDecorationRebuild(editor);
-
-      // Build IComment + meta and hand off to the consumer pipeline.
+      // Build IComment now so we can pre-populate local state and avoid a
+      // "Loading encrypted comments" flash while the consumer round-trips
+      // the new comment back through onNewComment → setInitialComments.
       const newComment: IComment = {
         id: draft.id,
         tabId: get().activeTabId,
+        username: get().username ?? undefined,
         selectedContent: draft.originalContent,
         content: '',
+        replies: [],
         isSuggestion: true,
         suggestionType,
         originalContent: draft.originalContent,
@@ -2461,6 +2496,25 @@ export const createCommentStore = () =>
         deleted: false,
         createdAt: new Date(),
       };
+
+      const nextMySubmitted = new Set(get().mySubmittedSuggestionIds);
+      nextMySubmitted.add(draft.id);
+
+      set({
+        drafts: nextDrafts,
+        floatingCards: nextCards,
+        mySubmittedSuggestionIds: nextMySubmitted,
+      });
+      if (draftAnchorsRef) {
+        draftAnchorsRef.current =
+          Object.values(nextDrafts).map(deriveDraftAnchor);
+      }
+      // Pre-populate initialComments / tabComments so the thread card renders
+      // with real data on the very next paint. Consumer's subsequent round-trip
+      // via onNewComment replaces this list harmlessly (same content + any
+      // extra metadata like commentIndex).
+      get().setInitialComments([...get().initialComments, newComment]);
+      triggerDecorationRebuild(editor);
 
       const meta: CommentMutationMeta = {
         type: 'create',

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -295,6 +295,13 @@ const hasResolvableCommentAnchor = ({
   anchor: CommentAnchor;
   editor: Editor;
 }) => {
+  // Add suggestions are point anchors (anchorFrom === anchorTo); range
+  // resolution rejects them. Use point resolution as the validity check
+  // for that case so the auto-spawned thread card isn't reconciled away.
+  if (anchor.isSuggestion && anchor.suggestionType === 'add') {
+    return resolveCommentAnchorPointInState(anchor, editor.state) !== null;
+  }
+
   const anchorRange = resolveCommentAnchorRangeInState(anchor, editor.state);
 
   return Boolean(anchorRange && anchorRange.from < anchorRange.to);
@@ -344,7 +351,15 @@ const hasValidHydratedThreadAnchor = ({
 }) => {
   const commentId = comment.id;
 
-  if (!commentId || !comment.selectedContent || editor.isDestroyed) {
+  if (!commentId || editor.isDestroyed) {
+    return false;
+  }
+
+  // Regular comments require selectedContent (the highlighted text to anchor
+  // to). Suggestions don't always have selectedContent — Add suggestions are
+  // point-anchored. Validity is determined by the anchor's resolvability,
+  // not by selectedContent.
+  if (!comment.isSuggestion && !comment.selectedContent) {
     return false;
   }
 
@@ -1829,7 +1844,17 @@ export const createCommentStore = () =>
             return;
           }
 
-          if (comment.deleted || comment.resolved || !comment.selectedContent) {
+          if (comment.deleted || comment.resolved) {
+            return;
+          }
+
+          // Regular comments require selectedContent (the highlighted text).
+          // Add suggestions are point-anchored and have no selectedContent —
+          // letting that gate filter them out makes the auto-spawned thread
+          // card disappear on every reconcile (sidebar toggle, live update,
+          // etc.). Suggestions are always allowed; their visibility is
+          // controlled by isSuggestion / accepted state instead.
+          if (!comment.isSuggestion && !comment.selectedContent) {
             return;
           }
 
@@ -2298,17 +2323,13 @@ export const createCommentStore = () =>
 
     appendToDraftAtCursor: (text) => {
       const deps = getExtDeps(get);
-      const { editor, draftAnchorsRef, setCommentDrawerOpen } = deps;
+      const { editor, draftAnchorsRef } = deps;
       if (!editor) return;
 
-      // Mirror the comment flow: until the viewer joins (sets a username /
-      // connects), surface the join drawer instead of starting a draft. The
-      // first keystroke triggers the prompt; once joined, subsequent keystrokes
-      // create the draft normally.
-      if (!get().isConnected) {
-        setCommentDrawerOpen?.(true);
-        return;
-      }
+      // The draft is created regardless of connection state. When !isConnected,
+      // SuggestionDraftFloatingCard renders FloatingAuthPrompt inside (same
+      // pattern as inline comments). The typed character is preserved as the
+      // first keystroke so the user keeps what they typed once they join.
 
       const currentDrafts = get().drafts;
       const activeDraft = findDraftAtEditorCursor(currentDrafts, editor.state);
@@ -2370,15 +2391,11 @@ export const createCommentStore = () =>
 
     startDeleteDraft: (from, to) => {
       const deps = getExtDeps(get);
-      const { editor, draftAnchorsRef, setCommentDrawerOpen } = deps;
+      const { editor, draftAnchorsRef } = deps;
       if (!editor) return;
       if (from >= to) return;
 
-      // Same join gate as appendToDraftAtCursor — see Bug 2 reasoning there.
-      if (!get().isConnected) {
-        setCommentDrawerOpen?.(true);
-        return;
-      }
+      // Draft is created regardless of connection state — see appendToDraftAtCursor.
 
       const anchorRange = createCommentAnchorFromEditor(editor, from, to);
       if (!anchorRange) return;

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -793,6 +793,7 @@ export interface CommentStoreState {
   cancelFloatingDraft: (draftId: string) => void;
   submitFloatingDraft: (draftId: string) => void;
   openFloatingThread: (commentId: string) => void;
+  focusSubmittedSuggestionFromEditor: (commentId: string) => boolean;
   closeFloatingCard: (floatingCardId: string) => void;
   blurFloatingCard: (floatingCardId: string) => void;
   focusFloatingCard: (floatingCardId: string) => void;
@@ -1789,6 +1790,37 @@ export const createCommentStore = () =>
       });
       setActiveCommentId(commentId);
       editor.commands.setCommentActive(commentId);
+    },
+    focusSubmittedSuggestionFromEditor: (commentId) => {
+      const { editor, setActiveCommentId } = getExtDeps(get);
+      const state = get();
+      const suggestionToFocus = state.tabComments.find(
+        (comment) =>
+          comment.id === commentId &&
+          comment.isSuggestion &&
+          !comment.deleted &&
+          !comment.resolved,
+      );
+
+      if (!editor || !suggestionToFocus) {
+        return false;
+      }
+
+      if (state.isDesktopFloatingEnabled) {
+        state.setActiveCommentId(commentId);
+        setActiveCommentId(commentId);
+        state.openFloatingThread(commentId);
+        return true;
+      }
+
+      state.setActiveCommentId(commentId);
+      setActiveCommentId(commentId);
+      editor.commands.setCommentActive(commentId);
+      set({
+        openReplyId: commentId,
+      });
+      state.setCommentDrawerOpen?.(true);
+      return true;
     },
     closeFloatingCard: (floatingCardId) => {
       const { editor, setActiveCommentId } = getExtDeps(get);

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -587,12 +587,6 @@ export interface CommentStoreState {
   pendingPrehydrationFloatingThreadIds: string[];
   /** In-progress suggestion drafts — keyed by suggestionId. Viewer-local, lost on refresh. */
   drafts: Record<string, DraftSuggestion>;
-  /**
-   * Suggestion IDs submitted from this session. Used to show the withdraw (X)
-   * action for viewers even when they don't have a persistent username set.
-   * Session-local, lost on refresh.
-   */
-  mySubmittedSuggestionIds: Set<string>;
   inlineDrafts: InlineDraftRecordMap;
   activeDraftId: string | null;
   isDesktopFloatingEnabled: boolean;
@@ -818,7 +812,6 @@ export const createCommentStore = () =>
     floatingCards: [],
     pendingPrehydrationFloatingThreadIds: [],
     drafts: {},
-    mySubmittedSuggestionIds: new Set<string>(),
     inlineDrafts: {},
     activeDraftId: null,
     isDesktopFloatingEnabled: false,
@@ -2586,13 +2579,9 @@ export const createCommentStore = () =>
         createdAt: new Date(),
       };
 
-      const nextMySubmitted = new Set(get().mySubmittedSuggestionIds);
-      nextMySubmitted.add(draft.id);
-
       set({
         drafts: nextDrafts,
         floatingCards: nextCards,
-        mySubmittedSuggestionIds: nextMySubmitted,
       });
       if (draftAnchorsRef) {
         draftAnchorsRef.current =

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -1479,7 +1479,11 @@ export const createCommentStore = () =>
 
       if (floatingCardToClose.type === 'draft') {
         editor?.commands.unsetDraftComment(floatingCardToClose.draftId);
-      } else if (editor && activeCommentId === floatingCardToClose.commentId) {
+      } else if (
+        floatingCardToClose.type === 'thread' &&
+        editor &&
+        activeCommentId === floatingCardToClose.commentId
+      ) {
         setActiveCommentId(null);
         editor.commands.unsetCommentActive();
       }

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -92,6 +92,8 @@ export interface DraftSuggestion {
   hadDeletion: boolean;
 }
 
+type SuggestionDeleteDirection = 'backward' | 'forward';
+
 function deriveDraftSuggestionType(draft: DraftSuggestion): SuggestionType {
   if (draft.hadDeletion) {
     return draft.insertedText.length > 0 ? 'replace' : 'delete';
@@ -132,6 +134,113 @@ function findDraftAtEditorCursor(
     }
   }
   return null;
+}
+
+function resolveDeleteRangeAtCursor(
+  state: EditorState,
+  direction: SuggestionDeleteDirection,
+): { from: number; to: number } | null {
+  const { from, empty } = state.selection;
+  if (!empty) {
+    return null;
+  }
+
+  return resolveDeleteRangeAtPosition(state, from, direction);
+}
+
+function resolveDeleteRangeAtPosition(
+  state: EditorState,
+  position: number,
+  direction: SuggestionDeleteDirection,
+): { from: number; to: number } | null {
+  const rangeFrom = direction === 'backward' ? position - 1 : position;
+  const rangeTo = direction === 'backward' ? position : position + 1;
+
+  if (
+    rangeFrom < 0 ||
+    rangeTo > state.doc.content.size ||
+    rangeFrom >= rangeTo
+  ) {
+    return null;
+  }
+
+  // Only create delete drafts for real inline text. Structural deletions
+  // (block joins, node boundaries, etc.) stay blocked in suggestion mode.
+  const deletedText = state.doc.textBetween(rangeFrom, rangeTo, '', '');
+  if (!deletedText) {
+    return null;
+  }
+
+  return { from: rangeFrom, to: rangeTo };
+}
+
+function isPureDeleteDraft(draft: DraftSuggestion): boolean {
+  return draft.hadDeletion && draft.insertedText.length === 0;
+}
+
+type SuggestionDraftStateSetter = (state: {
+  drafts: Record<string, DraftSuggestion>;
+  floatingCards: CommentFloatingCard[];
+}) => void;
+
+function syncSuggestionDraftState(
+  setState: SuggestionDraftStateSetter,
+  nextDrafts: Record<string, DraftSuggestion>,
+  nextCards: CommentFloatingCard[],
+  draftAnchorsRef?: React.MutableRefObject<CommentAnchor[]>,
+) {
+  setState({ drafts: nextDrafts, floatingCards: nextCards });
+  if (draftAnchorsRef) {
+    draftAnchorsRef.current = Object.values(nextDrafts).map(deriveDraftAnchor);
+  }
+}
+
+function updateDeleteDraftRange({
+  setState,
+  drafts,
+  floatingCards,
+  activeDraft,
+  editor,
+  draftAnchorsRef,
+  from,
+  to,
+  collapseTo,
+}: {
+  setState: SuggestionDraftStateSetter;
+  drafts: Record<string, DraftSuggestion>;
+  floatingCards: CommentFloatingCard[];
+  activeDraft: DraftSuggestion;
+  editor: Editor;
+  draftAnchorsRef?: React.MutableRefObject<CommentAnchor[]>;
+  from: number;
+  to: number;
+  collapseTo: number;
+}): boolean {
+  const nextAnchorRange = createCommentAnchorFromEditor(editor, from, to);
+  if (!nextAnchorRange) return false;
+
+  const nextOriginalContent = editor.state.doc.textBetween(from, to, '\n');
+  const nextDraft: DraftSuggestion = {
+    ...activeDraft,
+    anchorFrom: nextAnchorRange.anchorFrom,
+    anchorTo: nextAnchorRange.anchorTo,
+    originalContent: nextOriginalContent,
+  };
+  const nextDrafts = { ...drafts, [activeDraft.id]: nextDraft };
+  const nextCards = floatingCards.map((card) =>
+    card.type === 'suggestion-draft' && card.suggestionId === activeDraft.id
+      ? { ...card, selectedText: nextOriginalContent }
+      : card,
+  );
+
+  syncSuggestionDraftState(setState, nextDrafts, nextCards, draftAnchorsRef);
+
+  const tr = editor.state.tr.setSelection(
+    TextSelection.near(editor.state.doc.resolve(collapseTo)),
+  );
+  editor.view.dispatch(tr);
+  triggerDecorationRebuild(editor);
+  return true;
 }
 
 type FloatingCardsUpdater = React.SetStateAction<CommentFloatingCard[]>;
@@ -713,7 +822,20 @@ export interface CommentStoreState {
    * Captures originalContent, leaves insertedText empty; type becomes 'replace'
    * as soon as the viewer types.
    */
-  startDeleteDraft: (from: number, to: number) => void;
+  startDeleteDraft: (from: number, to: number, collapseTo?: number) => void;
+  /**
+   * Convert a collapsed-caret Backspace/Delete into a delete draft when the
+   * caret is adjacent to text, or shrink the active draft if the caret is
+   * already inside one.
+   */
+  deleteAtCursorOrUndoActiveDraft: (
+    direction: SuggestionDeleteDirection,
+  ) => void;
+  /**
+   * Handle browser deletion paths that resolved to a concrete range even
+   * though the user had no explicit selection.
+   */
+  deleteRangeOrUndoActiveDraft: (from: number, to: number) => void;
   /**
    * Undo the last keystroke in the draft at the current cursor position.
    * When the draft has no keystrokes left, it is discarded.
@@ -953,6 +1075,7 @@ export const createCommentStore = () =>
       }
     },
     setActiveCommentId: (id) => {
+      const previousActiveCommentId = get().activeCommentId;
       set({ activeCommentId: id });
 
       const tabComments = get().tabComments;
@@ -963,6 +1086,13 @@ export const createCommentStore = () =>
       );
 
       set({ activeComment, activeCommentIndex });
+
+      if (previousActiveCommentId !== id) {
+        const { editor } = getExtDeps(get);
+        if (editor) {
+          triggerDecorationRebuild(editor);
+        }
+      }
     },
     setActiveTabId: (tabId) => {
       const {
@@ -1729,11 +1859,15 @@ export const createCommentStore = () =>
       }));
 
       if (focusedFloatingCard.type === 'thread') {
+        // Take local ownership immediately so suggestion decorations rebuild
+        // with the active state on the same click, then mirror externally.
+        get().setActiveCommentId(focusedFloatingCard.commentId);
         setActiveCommentId(focusedFloatingCard.commentId);
         editor.commands.setCommentActive(focusedFloatingCard.commentId);
         return;
       }
 
+      get().setActiveCommentId(null);
       setActiveCommentId(null);
       editor.commands.unsetCommentActive();
     },
@@ -2386,7 +2520,7 @@ export const createCommentStore = () =>
       triggerDecorationRebuild(editor);
     },
 
-    startDeleteDraft: (from, to) => {
+    startDeleteDraft: (from, to, collapseTo) => {
       const deps = getExtDeps(get);
       const { editor, draftAnchorsRef } = deps;
       if (!editor) return;
@@ -2425,20 +2559,112 @@ export const createCommentStore = () =>
         newCard,
       ];
 
-      set({ drafts: nextDrafts, floatingCards: nextCards });
-      if (draftAnchorsRef) {
-        draftAnchorsRef.current =
-          Object.values(nextDrafts).map(deriveDraftAnchor);
-      }
+      syncSuggestionDraftState(set, nextDrafts, nextCards, draftAnchorsRef);
 
-      // Collapse the selection to `to` so the caret renders at the end of the
-      // strikethrough, matching Google Docs behavior.
+      // Collapse the selection at the requested caret position so Backspace
+      // stays at the end of the deleted range while forward Delete remains at
+      // the start.
+      const nextCaretPos = collapseTo ?? to;
       const tr = editor.state.tr.setSelection(
-        TextSelection.near(editor.state.doc.resolve(to)),
+        TextSelection.near(editor.state.doc.resolve(nextCaretPos)),
       );
       editor.view.dispatch(tr);
 
       triggerDecorationRebuild(editor);
+    },
+
+    deleteAtCursorOrUndoActiveDraft: (direction) => {
+      const deps = getExtDeps(get);
+      const { editor, draftAnchorsRef } = deps;
+      if (!editor) return;
+
+      const activeDraft = findDraftAtEditorCursor(get().drafts, editor.state);
+      if (activeDraft) {
+        if (isPureDeleteDraft(activeDraft)) {
+          const activeRange = resolveCommentAnchorRangeInState(
+            activeDraft,
+            editor.state,
+          );
+          if (!activeRange) return;
+
+          const extensionRange = resolveDeleteRangeAtPosition(
+            editor.state,
+            direction === 'backward' ? activeRange.from : activeRange.to,
+            direction,
+          );
+          if (!extensionRange) return;
+
+          updateDeleteDraftRange({
+            setState: set,
+            drafts: get().drafts,
+            floatingCards: get().floatingCards,
+            activeDraft,
+            editor,
+            draftAnchorsRef,
+            from: Math.min(activeRange.from, extensionRange.from),
+            to: Math.max(activeRange.to, extensionRange.to),
+            collapseTo:
+              direction === 'backward' ? activeRange.to : activeRange.from,
+          });
+          return;
+        }
+
+        get().undoLastKeystrokeInActiveDraft();
+        return;
+      }
+
+      const deleteRange = resolveDeleteRangeAtCursor(editor.state, direction);
+      if (!deleteRange) return;
+
+      const collapseTo =
+        direction === 'forward' ? deleteRange.from : deleteRange.to;
+
+      get().startDeleteDraft(deleteRange.from, deleteRange.to, collapseTo);
+    },
+
+    deleteRangeOrUndoActiveDraft: (from, to) => {
+      const deps = getExtDeps(get);
+      const { editor, draftAnchorsRef } = deps;
+      if (!editor) return;
+      if (from >= to) return;
+
+      const activeDraft = findDraftAtEditorCursor(get().drafts, editor.state);
+      if (activeDraft) {
+        if (isPureDeleteDraft(activeDraft)) {
+          const activeRange = resolveCommentAnchorRangeInState(
+            activeDraft,
+            editor.state,
+          );
+          if (!activeRange) return;
+
+          updateDeleteDraftRange({
+            setState: set,
+            drafts: get().drafts,
+            floatingCards: get().floatingCards,
+            activeDraft,
+            editor,
+            draftAnchorsRef,
+            from: Math.min(activeRange.from, from),
+            to: Math.max(activeRange.to, to),
+            collapseTo:
+              editor.state.selection.empty &&
+              from === editor.state.selection.from
+                ? from
+                : to,
+          });
+          return;
+        }
+
+        get().undoLastKeystrokeInActiveDraft();
+        return;
+      }
+
+      const collapseTo =
+        editor.state.selection.empty && from === editor.state.selection.from
+          ? from
+          : to;
+
+      get().startDeleteDraft(from, to, collapseTo);
     },
 
     undoLastKeystrokeInActiveDraft: () => {
@@ -2794,11 +3020,7 @@ export const createCommentStore = () =>
         return;
       }
 
-      if (foundComment.selectedContent) {
-        if (!editor?.view?.dom) {
-          return;
-        }
-
+      if (editor?.view?.dom) {
         const selectionRange = resolveCommentSelectionRange({
           editor,
           commentId,
@@ -2807,11 +3029,15 @@ export const createCommentStore = () =>
 
         if (selectionRange) {
           const tr = editor.state.tr.setSelection(
-            TextSelection.create(
-              editor.state.doc,
-              selectionRange.from,
-              selectionRange.to,
-            ),
+            selectionRange.from === selectionRange.to
+              ? TextSelection.near(
+                  editor.state.doc.resolve(selectionRange.from),
+                )
+              : TextSelection.create(
+                  editor.state.doc,
+                  selectionRange.from,
+                  selectionRange.to,
+                ),
           );
 
           if (options?.source === 'explicit-ui') {
@@ -2821,14 +3047,9 @@ export const createCommentStore = () =>
           }
 
           editor.view.dispatch(tr);
-        }
-
-        if (selectionRange) {
           set({ isBubbleMenuSuppressed: true });
           editor.commands.setCommentActive(commentId);
-        }
 
-        if (selectionRange) {
           // Keep the nested requestAnimationFrame so the editor selection and
           // active comment styling settle before measuring scroll coordinates.
           requestAnimationFrame(() => {
@@ -2842,6 +3063,9 @@ export const createCommentStore = () =>
         }
       }
 
+      // Keep suggestion-widget active styling in sync immediately instead of
+      // waiting for the external activeCommentId round-trip.
+      get().setActiveCommentId(commentId);
       setActiveCommentId(commentId);
     },
     onPrevComment: () => {

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -708,6 +708,16 @@ export interface CommentStoreState {
   /** Drop a draft entirely — removes the inline overlay and draft card. */
   discardDraft: (suggestionId: string) => void;
   /**
+   * Refresh the `originalContent` (and the suggestion-draft card's selectedText)
+   * for a Delete/Replace draft whose anchored range still resolves but now
+   * covers different text — happens when the owner edits within the anchored
+   * range while the viewer's draft is open.
+   */
+  refreshDraftOriginalContent: (
+    suggestionId: string,
+    currentText: string,
+  ) => void;
+  /**
    * Promote a draft to a submitted suggestion. Pushes the anchor into
    * commentAnchorsRef, calls onNewComment, removes the draft, and swaps the
    * suggestion-draft floating card for a thread card (same floatingCardId).
@@ -843,6 +853,13 @@ export const createCommentStore = () =>
       // SuggestionThreadFloatingCard to the generic ThreadFloatingCard. Merge
       // the local suggestion metadata back in for comments we already know are
       // suggestions in the current store.
+      //
+      // `deleted` / `resolved` are also merged monotonically (once locally true,
+      // stay true): if the viewer withdraws a suggestion whose create-comment
+      // cache write hadn't completed yet, the consumer's async delete write
+      // silently no-ops, and the subsequent `addCommentToCacheV2` writes the
+      // comment back as `deleted: false`. Without this guard, the next
+      // userMessages round-trip un-deletes the withdrawn suggestion locally.
       const previousById = new Map(
         get().initialComments.map((comment) => [comment.id, comment]),
       );
@@ -858,6 +875,8 @@ export const createCommentStore = () =>
           originalContent: comment.originalContent ?? previous.originalContent,
           suggestedContent:
             comment.suggestedContent ?? previous.suggestedContent,
+          deleted: comment.deleted || previous.deleted || false,
+          resolved: comment.resolved || previous.resolved || false,
         };
       });
 
@@ -2439,6 +2458,32 @@ export const createCommentStore = () =>
           Object.values(nextDrafts).map(deriveDraftAnchor);
       }
       if (editor) triggerDecorationRebuild(editor);
+    },
+
+    refreshDraftOriginalContent: (suggestionId, currentText) => {
+      const deps = getExtDeps(get);
+      const { draftAnchorsRef } = deps;
+      const currentDrafts = get().drafts;
+      const draft = currentDrafts[suggestionId];
+      if (!draft) return;
+      if (draft.originalContent === currentText) return;
+
+      const nextDraft: DraftSuggestion = {
+        ...draft,
+        originalContent: currentText,
+      };
+      const nextDrafts = { ...currentDrafts, [suggestionId]: nextDraft };
+      const nextCards = get().floatingCards.map((c) =>
+        c.type === 'suggestion-draft' && c.suggestionId === suggestionId
+          ? { ...c, selectedText: currentText }
+          : c,
+      );
+
+      set({ drafts: nextDrafts, floatingCards: nextCards });
+      if (draftAnchorsRef) {
+        draftAnchorsRef.current =
+          Object.values(nextDrafts).map(deriveDraftAnchor);
+      }
     },
 
     submitDraft: (suggestionId) => {

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -75,9 +75,9 @@ export interface CommentExternalDeps {
 /**
  * A suggestion draft is the viewer's in-progress proposed edit — kept local
  * until Submit. Drafts live in memory only (lost on refresh). Derived into
- * a CommentAnchor for decoration rendering via deriveDraftAnchor(). The
- * suggestion type ('add' | 'delete' | 'replace') is not stored; it is derived
- * at use time from hadDeletion + insertedText.
+ * a CommentAnchor for decoration rendering via deriveDraftAnchor(). Most
+ * suggestion types are derived at use time from hadDeletion + insertedText;
+ * linkHref marks a link suggestion over the original selected text.
  */
 export interface DraftSuggestion {
   id: string;
@@ -91,11 +91,20 @@ export interface DraftSuggestion {
   keystrokes: string[];
   /** True when the draft was created via select+delete or select+type. */
   hadDeletion: boolean;
+  /** Pasted link href for a link suggestion. */
+  linkHref?: string;
 }
 
 type SuggestionDeleteDirection = 'backward' | 'forward';
 
+export function isRangeDraft(draft: DraftSuggestion): boolean {
+  return draft.hadDeletion || Boolean(draft.linkHref);
+}
+
 function deriveDraftSuggestionType(draft: DraftSuggestion): SuggestionType {
+  if (draft.linkHref) {
+    return 'link';
+  }
   if (draft.hadDeletion) {
     return draft.insertedText.length > 0 ? 'replace' : 'delete';
   }
@@ -112,7 +121,7 @@ function deriveDraftAnchor(draft: DraftSuggestion): CommentAnchor {
     isSuggestion: true,
     suggestionType: deriveDraftSuggestionType(draft),
     originalContent: draft.originalContent,
-    suggestedContent: draft.insertedText,
+    suggestedContent: draft.linkHref ?? draft.insertedText,
   };
 }
 
@@ -122,8 +131,8 @@ function findDraftAtEditorCursor(
 ): DraftSuggestion | null {
   const { from, to } = state.selection;
   for (const draft of Object.values(drafts)) {
-    if (draft.hadDeletion) {
-      // Delete / Replace draft: cursor must be within [anchorFrom, anchorTo]
+    if (isRangeDraft(draft)) {
+      // Delete / Replace / Link draft: cursor must be within [anchorFrom, anchorTo]
       const range = resolveCommentAnchorRangeInState(draft, state);
       if (!range) continue;
       if (from >= range.from && to <= range.to) return draft;
@@ -824,6 +833,11 @@ export interface CommentStoreState {
    * as soon as the viewer types.
    */
   startDeleteDraft: (from: number, to: number, collapseTo?: number) => void;
+  /**
+   * Create a link suggestion from a selected range and pasted href.
+   * The document stays unchanged until the owner accepts the suggestion.
+   */
+  startLinkDraft: (from: number, to: number, href: string) => void;
   /**
    * Convert a collapsed-caret Backspace/Delete into a delete draft when the
    * caret is adjacent to text, or shrink the active draft if the caret is
@@ -2575,6 +2589,50 @@ export const createCommentStore = () =>
       triggerDecorationRebuild(editor);
     },
 
+    startLinkDraft: (from, to, href) => {
+      const deps = getExtDeps(get);
+      const { editor, draftAnchorsRef } = deps;
+      if (!editor) return;
+      if (from >= to || !href) return;
+
+      const anchorRange = createCommentAnchorFromEditor(editor, from, to);
+      if (!anchorRange) return;
+
+      const originalContent = editor.state.doc.textBetween(from, to, '\n');
+      if (!originalContent) return;
+
+      const id = `suggestion-${uuid()}`;
+      const newDraft: DraftSuggestion = {
+        id,
+        anchorFrom: anchorRange.anchorFrom,
+        anchorTo: anchorRange.anchorTo,
+        originalContent,
+        insertedText: '',
+        keystrokes: [],
+        hadDeletion: false,
+        linkHref: href,
+      };
+
+      const newCard: SuggestionFloatingDraftCard = {
+        type: 'suggestion-draft',
+        floatingCardId: `suggestion-draft:${id}`,
+        suggestionId: id,
+        selectedText: originalContent,
+        insertedText: '',
+        linkHref: href,
+        isFocused: true,
+      };
+
+      const nextDrafts = { ...get().drafts, [id]: newDraft };
+      const nextCards = [
+        ...get().floatingCards.map((c) => ({ ...c, isFocused: false })),
+        newCard,
+      ];
+
+      syncSuggestionDraftState(set, nextDrafts, nextCards, draftAnchorsRef);
+      triggerDecorationRebuild(editor);
+    },
+
     deleteAtCursorOrUndoActiveDraft: (direction) => {
       const deps = getExtDeps(get);
       const { editor, draftAnchorsRef } = deps;
@@ -2764,11 +2822,35 @@ export const createCommentStore = () =>
       const draft = get().drafts[suggestionId];
       if (!draft) return;
 
-      const suggestionType = deriveDraftSuggestionType(draft);
+      let draftToSubmit = draft;
+
+      if (isRangeDraft(draft)) {
+        const currentRange = resolveCommentAnchorRangeInState(
+          draft,
+          editor.state,
+        );
+        if (!currentRange) return;
+
+        const currentOriginalContent = editor.state.doc.textBetween(
+          currentRange.from,
+          currentRange.to,
+          '\n',
+        );
+        if (!currentOriginalContent) return;
+
+        if (currentOriginalContent !== draft.originalContent) {
+          draftToSubmit = {
+            ...draft,
+            originalContent: currentOriginalContent,
+          };
+        }
+      }
+
+      const suggestionType = deriveDraftSuggestionType(draftToSubmit);
 
       // Promote draft anchor into commentAnchorsRef so the decoration layer
       // reads it from the "submitted" source henceforth.
-      const submittedAnchor: CommentAnchor = deriveDraftAnchor(draft);
+      const submittedAnchor: CommentAnchor = deriveDraftAnchor(draftToSubmit);
       commentAnchorsRef.current = [
         ...commentAnchorsRef.current,
         submittedAnchor,
@@ -2786,8 +2868,8 @@ export const createCommentStore = () =>
         const threadCard: CommentFloatingThreadCard = {
           type: 'thread',
           floatingCardId: c.floatingCardId,
-          commentId: draft.id,
-          selectedText: draft.originalContent,
+          commentId: draftToSubmit.id,
+          selectedText: draftToSubmit.originalContent,
           isFocused: c.isFocused,
         };
         return threadCard;
@@ -2797,16 +2879,16 @@ export const createCommentStore = () =>
       // "Loading encrypted comments" flash while the consumer round-trips
       // the new comment back through onNewComment → setInitialComments.
       const newComment: IComment = {
-        id: draft.id,
+        id: draftToSubmit.id,
         tabId: get().activeTabId,
         username: get().username ?? undefined,
-        selectedContent: draft.originalContent,
+        selectedContent: draftToSubmit.originalContent,
         content: '',
         replies: [],
         isSuggestion: true,
         suggestionType,
-        originalContent: draft.originalContent,
-        suggestedContent: draft.insertedText,
+        originalContent: draftToSubmit.originalContent,
+        suggestedContent: draftToSubmit.linkHref ?? draftToSubmit.insertedText,
         resolved: false,
         deleted: false,
         createdAt: new Date(),
@@ -2829,11 +2911,15 @@ export const createCommentStore = () =>
 
       const meta: CommentMutationMeta = {
         type: 'create',
-        anchorFrom: fromUint8Array(Y.encodeRelativePosition(draft.anchorFrom)),
-        anchorTo: fromUint8Array(Y.encodeRelativePosition(draft.anchorTo)),
+        anchorFrom: fromUint8Array(
+          Y.encodeRelativePosition(draftToSubmit.anchorFrom),
+        ),
+        anchorTo: fromUint8Array(
+          Y.encodeRelativePosition(draftToSubmit.anchorTo),
+        ),
         suggestionType,
-        originalContent: draft.originalContent,
-        suggestedContent: draft.insertedText,
+        originalContent: draftToSubmit.originalContent,
+        suggestedContent: draftToSubmit.linkHref ?? draftToSubmit.insertedText,
       };
 
       onNewComment?.(newComment, meta);

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -3,6 +3,7 @@ import { createContext, useContext } from 'react';
 import React from 'react';
 import {
   CommentAnchor,
+  applyAcceptedSuggestion,
   createCommentAnchorFromEditor,
   resolveCommentAnchorRangeInState,
   triggerDecorationRebuild,
@@ -600,6 +601,7 @@ export interface CommentStoreState {
     commentId: string,
     options?: { skipExternalCallback?: boolean },
   ) => void;
+  acceptSuggestion: (commentId: string) => void;
   deleteReply: (commentId: string, replyId: string) => void;
   requestEditComment: (commentId: string) => void;
   requestEditReply: (commentId: string, replyId: string) => void;
@@ -2064,6 +2066,47 @@ export const createCommentStore = () =>
             state.pendingPrehydrationFloatingThreadIds,
             [commentId],
           ),
+      }));
+
+      if (get().activeCommentId === commentId) {
+        setActiveCommentId(null);
+      }
+    },
+    acceptSuggestion: (commentId) => {
+      const { editor, onResolveComment, setActiveCommentId, commentAnchorsRef } =
+        getExtDeps(get);
+
+      if (!editor) return;
+
+      const anchor = commentAnchorsRef?.current.find(
+        (a) => a.id === commentId && a.isSuggestion,
+      );
+
+      if (!anchor || !commentAnchorsRef) return;
+
+      const applied = applyAcceptedSuggestion(editor, anchor);
+      if (!applied) return;
+
+      commentAnchorsRef.current = commentAnchorsRef.current.filter(
+        (a) => a.id !== commentId,
+      );
+      triggerDecorationRebuild(editor);
+
+      onResolveComment?.(commentId, {
+        type: 'resolve',
+        suggestionType: anchor.suggestionType,
+        originalContent: anchor.originalContent,
+        suggestedContent: anchor.suggestedContent,
+      });
+
+      set((state) => ({
+        floatingCards: state.floatingCards.filter(
+          (floatingCard) =>
+            !(
+              floatingCard.type === 'thread' &&
+              floatingCard.commentId === commentId
+            ),
+        ),
       }));
 
       if (get().activeCommentId === commentId) {

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -2298,8 +2298,17 @@ export const createCommentStore = () =>
 
     appendToDraftAtCursor: (text) => {
       const deps = getExtDeps(get);
-      const { editor, draftAnchorsRef } = deps;
+      const { editor, draftAnchorsRef, setCommentDrawerOpen } = deps;
       if (!editor) return;
+
+      // Mirror the comment flow: until the viewer joins (sets a username /
+      // connects), surface the join drawer instead of starting a draft. The
+      // first keystroke triggers the prompt; once joined, subsequent keystrokes
+      // create the draft normally.
+      if (!get().isConnected) {
+        setCommentDrawerOpen?.(true);
+        return;
+      }
 
       const currentDrafts = get().drafts;
       const activeDraft = findDraftAtEditorCursor(currentDrafts, editor.state);
@@ -2361,9 +2370,15 @@ export const createCommentStore = () =>
 
     startDeleteDraft: (from, to) => {
       const deps = getExtDeps(get);
-      const { editor, draftAnchorsRef } = deps;
+      const { editor, draftAnchorsRef, setCommentDrawerOpen } = deps;
       if (!editor) return;
       if (from >= to) return;
+
+      // Same join gate as appendToDraftAtCursor — see Bug 2 reasoning there.
+      if (!get().isConnected) {
+        setCommentDrawerOpen?.(true);
+        return;
+      }
 
       const anchorRange = createCommentAnchorFromEditor(editor, from, to);
       if (!anchorRange) return;

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -2271,8 +2271,12 @@ export const createCommentStore = () =>
       }
     },
     acceptSuggestion: (commentId) => {
-      const { editor, onResolveComment, setActiveCommentId, commentAnchorsRef } =
-        getExtDeps(get);
+      const {
+        editor,
+        onResolveComment,
+        setActiveCommentId,
+        commentAnchorsRef,
+      } = getExtDeps(get);
 
       if (!editor) return;
 
@@ -2486,7 +2490,8 @@ export const createCommentStore = () =>
       delete nextDrafts[suggestionId];
 
       const nextCards = get().floatingCards.filter(
-        (c) => !(c.type === 'suggestion-draft' && c.suggestionId === suggestionId),
+        (c) =>
+          !(c.type === 'suggestion-draft' && c.suggestionId === suggestionId),
       );
 
       set({ drafts: nextDrafts, floatingCards: nextCards });

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -6,7 +6,6 @@ import {
   applyAcceptedSuggestion,
   createCommentAnchorFromEditor,
   createCommentAnchorPointFromEditor,
-  getCommentAnchorRange,
   resolveCommentAnchorPointInState,
   resolveCommentAnchorRangeInState,
   triggerDecorationRebuild,
@@ -433,6 +432,13 @@ const areFloatingCardsEqual = (
     if (leftCard.type === 'draft') {
       return (
         rightCard.type === 'draft' && leftCard.draftId === rightCard.draftId
+      );
+    }
+
+    if (leftCard.type === 'suggestion-draft') {
+      return (
+        rightCard.type === 'suggestion-draft' &&
+        leftCard.suggestionId === rightCard.suggestionId
       );
     }
 
@@ -1916,6 +1922,12 @@ export const createCommentStore = () =>
 
       floatingCards.forEach((floatingCard) => {
         if (floatingCard.type === 'draft') {
+          nextFloatingCards.push(floatingCard);
+          return;
+        }
+
+        if (floatingCard.type === 'suggestion-draft') {
+          // Suggestion drafts are managed by the draft-model actions; preserve here.
           nextFloatingCards.push(floatingCard);
           return;
         }

--- a/package/stores/comment-store.ts
+++ b/package/stores/comment-store.ts
@@ -879,6 +879,7 @@ export interface CommentStoreState {
     commentId: string,
     options?: FocusCommentInEditorOptions,
   ) => void;
+  focusSuggestionDraftInEditor: (suggestionId: string) => void;
   onPrevComment: () => void;
   onNextComment: () => void;
   getEnsStatus: (
@@ -3067,6 +3068,62 @@ export const createCommentStore = () =>
       // waiting for the external activeCommentId round-trip.
       get().setActiveCommentId(commentId);
       setActiveCommentId(commentId);
+    },
+    focusSuggestionDraftInEditor: (suggestionId) => {
+      const { editor, setActiveCommentId } = getExtDeps(get);
+      const draft = get().drafts[suggestionId];
+
+      if (!editor?.view?.dom || !draft) {
+        return;
+      }
+
+      const anchor = deriveDraftAnchor(draft);
+      const selectionRange =
+        anchor.suggestionType === 'add'
+          ? (() => {
+              const point = resolveCommentAnchorPointInState(
+                anchor,
+                editor.state,
+              );
+              return point === null ? null : { from: point, to: point };
+            })()
+          : resolveCommentAnchorRangeInState(anchor, editor.state);
+
+      if (!selectionRange) {
+        return;
+      }
+
+      const tr = editor.state.tr.setSelection(
+        selectionRange.from === selectionRange.to
+          ? TextSelection.near(editor.state.doc.resolve(selectionRange.from))
+          : TextSelection.create(
+              editor.state.doc,
+              selectionRange.from,
+              selectionRange.to,
+            ),
+      );
+
+      editor.view.dispatch(tr);
+      editor.view.focus();
+      set({ isBubbleMenuSuppressed: true });
+      get().setActiveCommentId(null);
+      setActiveCommentId(null);
+      editor.commands.unsetCommentActive();
+      set((state) => ({
+        floatingCards: setFocusedFloatingCard(
+          state.floatingCards,
+          `suggestion-draft:${suggestionId}`,
+        ),
+      }));
+
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          scrollCommentSelectionRangeIntoView({
+            editor,
+            selectionRange,
+          });
+        });
+      });
     },
     onPrevComment: () => {
       const { editor } = getExtDeps(get);

--- a/package/styles/editor.scss
+++ b/package/styles/editor.scss
@@ -1176,6 +1176,25 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
   }
 }
 
+// Suggestion mode decorations
+.suggestion-delete {
+  @apply line-through cursor-pointer transition-all;
+  color: #EF4444;
+
+  .dark & {
+    color: #F87171;
+  }
+}
+
+.suggestion-add {
+  @apply underline cursor-pointer;
+  color: #16A34A;
+
+  .dark & {
+    color: #4ADE80;
+  }
+}
+
 // Hide inline comments visually when disabled
 .hide-inline-comments .inline-comment {
   background-color: transparent !important;

--- a/package/styles/editor.scss
+++ b/package/styles/editor.scss
@@ -1190,25 +1190,44 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
 // from inline-comment highlights via hue.
 .suggestion-delete {
   @apply cursor-pointer transition-all;
-  background-color: #FEE2E2;
+  background-color: rgba(251, 52, 73, 0.04);
   text-decoration: line-through;
-  text-decoration-color: #EF4444;
+  text-decoration-color: #FB3449;
   text-decoration-thickness: 1.5px;
 
+  &[data-active='true'],
+  &:hover {
+background-color: rgba(251, 52, 73, 0.08);
+  }
+
   .dark & {
-    background-color: #450A0A;
-    text-decoration-color: #F87171;
+        background-color: #450A0A;    text-decoration-color: #F87171;
+
+    &[data-active='true'],
+    &:hover {
+      background-color: rgb(248 113 113 / 0.08);
+    }
   }
 }
 
 .suggestion-add {
-  @apply cursor-pointer;
-  background-color: #DCFCE7;
-  color: #16A34A;
+  @apply cursor-pointer transition-all;
+background-color: rgba(0, 102, 7, 0.04);
+color: #006607;
+
+  &[data-active='true'],
+  &:hover {
+background-color: rgba(0, 102, 7, 0.08);
+  }
 
   .dark & {
-    background-color: #052E16;
-    color: #4ADE80;
+        background-color: #052E16;
+        color: #006607;
+
+    &[data-active='true'],
+    &:hover {
+      background-color: rgb(74 222 128 / 0.08);
+    }
   }
 }
 

--- a/package/styles/editor.scss
+++ b/package/styles/editor.scss
@@ -4,6 +4,13 @@
   color: inherit;
   font-family: inherit;
 
+  // Suppress all empty-line placeholder hints in suggestion mode.
+  // Slash commands don't fire in suggest mode (text input is intercepted),
+  // so "Type / to browse options" is misleading there.
+  &[data-suggestion-mode='true'] .is-empty::before {
+    content: none !important;
+  }
+
   .is-empty::before {
     @apply float-left h-0 pointer-events-none w-full;
   }
@@ -1180,18 +1187,22 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
 .suggestion-delete {
   @apply line-through cursor-pointer transition-all;
   color: #EF4444;
+  background-color: #FEE2E2;
 
   .dark & {
     color: #F87171;
+    background-color: #450A0A;
   }
 }
 
 .suggestion-add {
   @apply underline cursor-pointer;
   color: #16A34A;
+  background-color: #DCFCE7;
 
   .dark & {
     color: #4ADE80;
+    background-color: #052E16;
   }
 }
 

--- a/package/styles/editor.scss
+++ b/package/styles/editor.scss
@@ -1221,6 +1221,20 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
   pointer-events: none !important;
 }
 
+// Suggestions: hide both Add (widget) and Delete/Replace (decoration) so the
+// View-only viewer sees the canonical doc text without proposed changes.
+.hide-inline-comments .suggestion-add {
+  display: none !important;
+}
+
+.hide-inline-comments .suggestion-delete {
+  background-color: transparent !important;
+  color: inherit !important;
+  text-decoration: none !important;
+  cursor: default !important;
+  pointer-events: none !important;
+}
+
 .custom-scrollbar {
   overflow-y: scroll;
   scrollbar-width: thin; /* Firefox */

--- a/package/styles/editor.scss
+++ b/package/styles/editor.scss
@@ -1213,17 +1213,18 @@ background-color: rgba(251, 52, 73, 0.08);
 
 .suggestion-add {
   @apply cursor-pointer transition-all;
-background-color: rgba(0, 102, 7, 0.04);
-color: #006607;
+  background-color: rgba(0, 102, 7, 0.04);
+  color: #006607;
 
   &[data-active='true'],
   &:hover {
-background-color: rgba(0, 102, 7, 0.08);
+    background-color: rgba(0, 102, 7, 0.08);
   }
 
-  .dark & {
-        background-color: #052E16;
-        color: #006607;
+  .dark &,
+  .theme-green & {
+    color: #44FF00;
+    background-color: rgba(255, 255, 255, 0.04);
 
     &[data-active='true'],
     &:hover {
@@ -1244,6 +1245,17 @@ background-color: rgba(0, 102, 7, 0.08);
   &:hover {
     background-color: rgba(92, 10, 255, 0.08);
     text-decoration-color: rgba(92, 10, 255, 0.14);
+  }
+
+  .dark &,
+  .theme-green & {
+    color: #5BC3EB;
+    text-decoration-color: rgba(91, 195, 235, 0.28);
+
+    &[data-active='true'],
+    &:hover {
+      text-decoration-color: rgba(91, 195, 235, 0.42);
+    }
   }
 }
 

--- a/package/styles/editor.scss
+++ b/package/styles/editor.scss
@@ -1238,10 +1238,12 @@ background-color: rgba(0, 102, 7, 0.08);
   background-color: rgba(92, 10, 255, 0.04);
   text-decoration: underline;
   text-decoration-thickness: 2px;
+  text-decoration-color: rgba(92, 10, 255, 0.08);
 
   &[data-active='true'],
   &:hover {
     background-color: rgba(92, 10, 255, 0.08);
+    text-decoration-color: rgba(92, 10, 255, 0.14);
   }
 }
 

--- a/package/styles/editor.scss
+++ b/package/styles/editor.scss
@@ -1184,25 +1184,31 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
 }
 
 // Suggestion mode decorations
+// Suggestion styling: light tinted background + decoration. Text color
+// stays default so the doc text reads naturally; the colored decoration
+// (line-through / underline) carries the semantic. The bg differentiates
+// from inline-comment highlights via hue.
 .suggestion-delete {
-  @apply line-through cursor-pointer transition-all;
-  color: #EF4444;
+  @apply cursor-pointer transition-all;
   background-color: #FEE2E2;
+  text-decoration: line-through;
+  text-decoration-color: #EF4444;
+  text-decoration-thickness: 1.5px;
 
   .dark & {
-    color: #F87171;
     background-color: #450A0A;
+    text-decoration-color: #F87171;
   }
 }
 
 .suggestion-add {
-  @apply underline cursor-pointer;
-  color: #16A34A;
+  @apply cursor-pointer;
   background-color: #DCFCE7;
+  color: #16A34A;
 
   .dark & {
-    color: #4ADE80;
     background-color: #052E16;
+    color: #4ADE80;
   }
 }
 

--- a/package/styles/editor.scss
+++ b/package/styles/editor.scss
@@ -1232,6 +1232,19 @@ background-color: rgba(0, 102, 7, 0.08);
   }
 }
 
+.suggestion-link {
+  @apply cursor-pointer transition-all;
+  color: #5C0AFF;
+  background-color: rgba(92, 10, 255, 0.04);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+
+  &[data-active='true'],
+  &:hover {
+    background-color: rgba(92, 10, 255, 0.08);
+  }
+}
+
 // Hide inline comments visually when disabled
 .hide-inline-comments .inline-comment {
   background-color: transparent !important;
@@ -1251,6 +1264,13 @@ background-color: rgba(0, 102, 7, 0.08);
   background-color: transparent !important;
   color: inherit !important;
   text-decoration: none !important;
+  cursor: default !important;
+  pointer-events: none !important;
+}
+
+.hide-inline-comments .suggestion-link {
+  background-color: transparent !important;
+  color: inherit !important;
   cursor: default !important;
   pointer-events: none !important;
 }

--- a/package/types.ts
+++ b/package/types.ts
@@ -48,6 +48,8 @@ export type CommentMutationType =
   | 'unresolve'
   | 'delete';
 
+export type SuggestionType = 'add' | 'replace' | 'delete';
+
 export interface CommentMutationMeta {
   type: CommentMutationType;
   updateChunk?: string;
@@ -55,6 +57,9 @@ export interface CommentMutationMeta {
   anchorTo?: string;
   selectedContent?: string;
   content?: string;
+  suggestionType?: SuggestionType;
+  originalContent?: string;
+  suggestedContent?: string;
 }
 
 export interface SerializedCommentAnchor {
@@ -63,6 +68,10 @@ export interface SerializedCommentAnchor {
   anchorTo: string;
   resolved: boolean;
   deleted: boolean;
+  isSuggestion?: boolean;
+  suggestionType?: SuggestionType;
+  originalContent?: string;
+  suggestedContent?: string;
 }
 
 export interface CommentAccountProps {
@@ -204,6 +213,7 @@ export interface DdocProps extends CommentAccountProps {
   editorCanvasClassNames?: string;
   isCommentSectionOpen?: boolean;
   isPreviewMode: boolean;
+  viewerMode?: 'suggest' | 'view-only';
   ensResolutionUrl?: string;
   ipfsImageUploadFn?: (file: File) => Promise<IpfsImageUploadResponse>;
   enableIndexeddbSync?: boolean;

--- a/package/types.ts
+++ b/package/types.ts
@@ -48,7 +48,7 @@ export type CommentMutationType =
   | 'unresolve'
   | 'delete';
 
-export type SuggestionType = 'add' | 'replace' | 'delete';
+export type SuggestionType = 'add' | 'replace' | 'delete' | 'link';
 
 export interface CommentMutationMeta {
   type: CommentMutationType;

--- a/package/use-ddoc-editor.tsx
+++ b/package/use-ddoc-editor.tsx
@@ -7,6 +7,7 @@ import { Editor } from '@tiptap/react';
 
 export const useDdocEditor = ({
   isPreviewMode,
+  viewerMode,
   initialContent,
   versionHistoryState,
   collaboration,
@@ -39,6 +40,7 @@ export const useDdocEditor = ({
   onIndexedDbError,
   disableInlineComment,
   initialCommentAnchors,
+  onNewComment,
   ...rest
 }: Partial<DdocProps> & { isFocusMode?: boolean }) => {
   const [isContentLoading, setIsContentLoading] = useState(true);
@@ -95,6 +97,7 @@ export const useDdocEditor = ({
   const tabEditor = useTabEditor({
     ydoc: yjsSetup.ydoc,
     isPreviewMode,
+    viewerMode,
     initialContent: ddocContent,
     collaboration,
     versionId: versionHistoryState?.versionId,
@@ -136,6 +139,7 @@ export const useDdocEditor = ({
     theme,
     editorRef,
     initialCommentAnchors,
+    onNewComment,
   });
 
   const isOwner = collabEnabled ? collaboration.connection.isOwner : true;

--- a/package/use-ddoc-editor.tsx
+++ b/package/use-ddoc-editor.tsx
@@ -40,7 +40,6 @@ export const useDdocEditor = ({
   onIndexedDbError,
   disableInlineComment,
   initialCommentAnchors,
-  onNewComment,
   ...rest
 }: Partial<DdocProps> & { isFocusMode?: boolean }) => {
   const [isContentLoading, setIsContentLoading] = useState(true);
@@ -139,7 +138,6 @@ export const useDdocEditor = ({
     theme,
     editorRef,
     initialCommentAnchors,
-    onNewComment,
   });
 
   const isOwner = collabEnabled ? collaboration.connection.isOwner : true;

--- a/package/utils/comment-anchor-serialization.ts
+++ b/package/utils/comment-anchor-serialization.ts
@@ -27,7 +27,7 @@ export const deserializeCommentAnchors = (
   return anchors
     .map((anchor) => {
       try {
-        return {
+        const base: CommentAnchor = {
           id: anchor.id,
           anchorFrom: Y.decodeRelativePosition(
             Uint8Array.from(atob(anchor.anchorFrom), (char) =>
@@ -42,6 +42,18 @@ export const deserializeCommentAnchors = (
           resolved: anchor.resolved,
           deleted: anchor.deleted,
         };
+
+        // Preserve suggestion metadata so suggestion decorations render
+        // correctly after reload (cache schema for suggestions evolves;
+        // package can't render them without these fields).
+        if (anchor.isSuggestion) {
+          base.isSuggestion = true;
+          base.suggestionType = anchor.suggestionType;
+          base.originalContent = anchor.originalContent;
+          base.suggestedContent = anchor.suggestedContent;
+        }
+
+        return base;
       } catch {
         return null;
       }

--- a/package/utils/comment-scroll-into-view.ts
+++ b/package/utils/comment-scroll-into-view.ts
@@ -4,6 +4,7 @@ import { getCommentMarkRange } from '../extensions/comment';
 import {
   CommentAnchor,
   getCommentAnchorRange,
+  resolveCommentAnchorPointInState,
 } from '../extensions/comment/comment-decoration-plugin';
 import { getEditorScrollContainer } from './get-editor-scroll-container';
 
@@ -105,12 +106,31 @@ export const resolveCommentSelectionRange = ({
   commentId: string;
   commentAnchorsRef?: MutableRefObject<CommentAnchor[]>;
 }): CommentSelectionRange | null => {
-  const anchorRange = commentAnchorsRef
-    ? getCommentAnchorRange(editor, commentId, () => commentAnchorsRef.current)
-    : null;
+  const anchor = commentAnchorsRef?.current.find(
+    (entry) => entry.id === commentId && !entry.deleted,
+  );
+  const anchorRange =
+    anchor && commentAnchorsRef
+      ? getCommentAnchorRange(
+          editor,
+          commentId,
+          () => commentAnchorsRef.current,
+        )
+      : null;
 
   if (anchorRange) {
     return anchorRange;
+  }
+
+  // Add suggestions are point anchors, so they do not resolve to a text range.
+  // Return a collapsed selection at the anchor so click-to-focus can still
+  // move the caret and scroll the editor to the suggestion location.
+  if (anchor?.isSuggestion && anchor.suggestionType === 'add') {
+    const point = resolveCommentAnchorPointInState(anchor, editor.state);
+
+    if (point !== null) {
+      return { from: point, to: point };
+    }
   }
 
   // Legacy mark comments do not have decoration anchors, so prefer the full


### PR DESCRIPTION
## Summary

Adds Google Docs-style suggestion mode for viewers with comment permission. Viewers can propose edits (Add / Delete / Replace) that the document owner reviews and accepts/rejects. The document is never modified during suggestion composition — only the owner's Accept dispatches a doc-changing transaction.

Sits on top of Joshua's comment refactor (#477).

## What's in here

- **Keystroke interception** (`SuggestionTrackingExtension`) — intercepts every input event in suggest mode via PM plugin props; the doc never mutates until Accept.
- **Draft model** in the store — viewer's in-progress suggestions live in `useCommentStore.drafts` (lost on refresh, intentional). Submitted suggestions promote to `commentAnchorsRef`, the same anchor system regular comments use.
- **Decoration rendering** — green underlined widget for Add, red strikethrough for Delete, both for Replace. Light bg tints. `data-suggestion-id` + `data-comment-id` so layout engine resolves both draft and submitted suggestions.
- **Floating cards** — `SuggestionDraftFloatingCard` (Submit / Discard) and `SuggestionThreadFloatingCard` (Accept/Reject for owner, Withdraw for author, replies list inline).
- **Provider wiring** — auto-spawn thread cards, prune stale drafts, refresh partial-deletion drafts, monotonic `deleted`/`resolved` merge in `setInitialComments` to defeat racy create+delete cache writes.
- **Comment-active DOM sync** — excludes suggestion decorations (`:not([data-suggestion-id])`) so widgets don't get re-rendered out of existence on click-away.
- **Demo** — single mode-cycle button (Owner → Suggest → View-only).

## Architecture refs

- Spec: `docs/suggestion-mode-spec.md` (in ddocs.new repo)
- Architecture: `docs/architecture/suggestion-mode-architecture.md` (in ddocs.new repo)
- Test cases: `docs/testing/suggestion-mode-test-cases.md` (in ddocs.new repo)

## Test plan

Manual smoke test in the demo (`npm run dev`):

- [ ] Toggle Owner → Viewer/Suggest in the navbar
- [ ] Type at cursor → green Add widget appears, doc text unchanged (`editor.getJSON()` identical before/after)
- [ ] Select text + Backspace → red strikethrough Delete
- [ ] Select text + type → Replace (strikethrough + green widget)
- [ ] Discard removes overlay and card
- [ ] Submit promotes to thread card; Accept (owner) updates the doc; Reject/Withdraw clears
- [ ] Replies on submitted suggestions render inside the card
- [ ] Click on a suggestion decoration after closing the sidebar reopens its thread card
- [ ] Multi-suggestion: drafting a new one doesn't hide existing thread cards

Full case list: `docs/testing/suggestion-mode-test-cases.md` in ddocs.new (52 cases, A.01 – N.02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)