### PR TITLE
iframe crash fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "3.4.3",
+      "version": "3.4.4",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package/extensions/d-block/dblock-node-view.tsx
+++ b/package/extensions/d-block/dblock-node-view.tsx
@@ -84,12 +84,6 @@ export const DBlockNodeView: React.FC<NodeViewProps> = React.memo(
       return content[0].content.content[0]?.text;
     }, [node.content]);
 
-    const nodeContentLink = useMemo(() => {
-      const { content } = node.content as any;
-
-      return content[0].content.content[1]?.text;
-    }, [node.content]);
-
     const nodeTweetContentLink = useMemo(() => {
       const { content } = node.content as any;
 
@@ -114,13 +108,6 @@ export const DBlockNodeView: React.FC<NodeViewProps> = React.memo(
         // Handle image
         if (urlSrc && /\.(jpeg|jpg|gif|png)$/i.test(urlSrc)) {
           setMedia('img', urlSrc);
-          return;
-        }
-
-        // Handle iframe
-        if (nodeContentText.includes('<iframe')) {
-          const src = nodeContentLink;
-          setMedia('iframe', src);
           return;
         }
 

--- a/package/extensions/iframe/iframe.ts
+++ b/package/extensions/iframe/iframe.ts
@@ -3,6 +3,7 @@ import { Node, mergeAttributes } from '@tiptap/core';
 import { ReactNodeViewRenderer } from '@tiptap/react';
 import { getResizableMediaNodeView } from '../resizable-media/resizable-media-node-view';
 import { IpfsImageFetchPayload } from '../../types';
+import { isAllowedEmbedSrc } from '../../utils/is-allowed-embed-src';
 
 export interface IframeOptions {
   allowFullscreen: boolean;
@@ -103,6 +104,13 @@ export const Iframe = Node.create<IframeOptions>({
     return [
       {
         tag: 'iframe',
+        getAttrs: (el) => {
+          const src = (el as HTMLElement).getAttribute('src');
+          if (!isAllowedEmbedSrc(src)) return false;
+          const width = (el as HTMLElement).getAttribute('width');
+          const height = (el as HTMLElement).getAttribute('height');
+          return { src, width, height };
+        },
       },
     ];
   },
@@ -117,8 +125,9 @@ export const Iframe = Node.create<IframeOptions>({
   addCommands() {
     return {
       setIframe:
-        (options: { src: string }) =>
+        (options: { src: string; width?: number; height?: number }) =>
         ({ tr, dispatch }) => {
+          if (!isAllowedEmbedSrc(options.src)) return false;
           const { selection } = tr;
           const node = this.type.create(options);
 

--- a/package/extensions/mardown-paste-handler/index.ts
+++ b/package/extensions/mardown-paste-handler/index.ts
@@ -23,6 +23,7 @@ import {
 } from '../../utils/image-compression';
 import { markdownHtmlGuardPlugin } from './mark-down-html-guard-plugin';
 import { parseHeadingLink } from '../../utils/heading-link';
+import { isAllowedEmbedSrc } from '../../utils/is-allowed-embed-src';
 
 // Initialize MarkdownIt for converting Markdown back to HTML with footnote support.
 const markdownIt = new MarkdownIt({ html: true })
@@ -436,6 +437,46 @@ const MarkdownPasteHandler = (
               }
 
               event.preventDefault();
+
+              // Pasted text containing a raw <iframe> tag: if its src is on
+              // the embed allowlist, insert as an embed; otherwise drop in
+              // as literal text. Else tiptap-markdown's `html: true` paste
+              // path either turns it into an HTML iframe with an arbitrary
+              // src (XSS) or our schema drops it (leaving nothing).
+              if (copiedData && /<iframe\b/i.test(copiedData)) {
+                const srcMatch = copiedData.match(
+                  /<iframe\b[^>]*\bsrc=(?:"([^"]*)"|'([^']*)')/i,
+                );
+                const src = srcMatch?.[1] ?? srcMatch?.[2];
+                if (isAllowedEmbedSrc(src)) {
+                  const widthMatch = copiedData.match(
+                    /\bwidth=(?:"([^"]*)"|'([^']*)')/i,
+                  );
+                  const heightMatch = copiedData.match(
+                    /\bheight=(?:"([^"]*)"|'([^']*)')/i,
+                  );
+                  const width = parseInt(
+                    widthMatch?.[1] ?? widthMatch?.[2] ?? '',
+                    10,
+                  );
+                  const height = parseInt(
+                    heightMatch?.[1] ?? heightMatch?.[2] ?? '',
+                    10,
+                  );
+                  this.editor
+                    .chain()
+                    .focus()
+                    .setIframe({
+                      src,
+                      width: Number.isFinite(width) ? width : 640,
+                      height: Number.isFinite(height) ? height : 360,
+                    })
+                    .run();
+                } else {
+                  view.dispatch(view.state.tr.insertText(copiedData));
+                }
+                return true;
+              }
 
               // Check if we're in a code block
               const { state } = view;

--- a/package/extensions/resizable-media/resizable-media-node-view.tsx
+++ b/package/extensions/resizable-media/resizable-media-node-view.tsx
@@ -38,6 +38,7 @@ export const getResizableMediaNodeView =
 
     const isSoundcloudIframe =
       mediaType === 'iframe' &&
+      URL.canParse(node.attrs.src) &&
       new URL(node.attrs.src).hostname === 'w.soundcloud.com';
 
     const [aspectRatio, setAspectRatio] = useState(0);

--- a/package/utils/is-allowed-embed-src.ts
+++ b/package/utils/is-allowed-embed-src.ts
@@ -1,0 +1,21 @@
+// Allowlist for iframe `src` URLs. Only hosts/paths produced by the
+// in-app embed flows (YouTube, Vimeo, SoundCloud) are accepted. Everything
+// else is rejected to prevent loading arbitrary third-party frames.
+const ALLOWED_EMBEDS: { host: string; pathPrefix: string }[] = [
+  { host: 'www.youtube.com', pathPrefix: '/embed/' },
+  { host: 'youtube.com', pathPrefix: '/embed/' },
+  { host: 'www.youtube-nocookie.com', pathPrefix: '/embed/' },
+  { host: 'youtube-nocookie.com', pathPrefix: '/embed/' },
+  { host: 'player.vimeo.com', pathPrefix: '/video/' },
+  { host: 'w.soundcloud.com', pathPrefix: '/player' },
+];
+
+export function isAllowedEmbedSrc(src: unknown): src is string {
+  if (typeof src !== 'string' || !URL.canParse(src)) return false;
+  const url = new URL(src);
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return false;
+  return ALLOWED_EMBEDS.some(
+    ({ host, pathPrefix }) =>
+      url.hostname === host && url.pathname.startsWith(pathPrefix),
+  );
+}


### PR DESCRIPTION
Bug: pasting <iframe></iframe> crashed the editor with TypeError: Failed to construct 'URL': Invalid URL. Underlying issue: arbitrary iframe HTML flowed into
  the document with zero validation, an XSS surface.

  Fix — single allowlist, enforced at every boundary:

  - `package/utils/is-allowed-embed-src.ts` (new) — sole source of truth. Allows only www.youtube.com/youtube.com/*.youtube-nocookie.com /embed/, player.vimeo.com
  /video/, and w.soundcloud.com /player.
  - `extensions/iframe/iframe.ts` —
    - parseHTML.getAttrs: rejects iframes whose src isn't allowlisted (returns false, element is dropped). Also preserves width/height.
    - setIframe command: returns false if src isn't allowlisted. Final defensive gate.
  - `extensions/resizable-media/resizable-media-node-view.tsx` — the original crash site (new URL(node.attrs.src)) wrapped with URL.canParse guard.
  - `extensions/mardown-paste-handler/index.ts` handlePaste — when pasted text contains <iframe>, extract src + width/height from the snippet. If src passes the
  allowlist → setIframe embed; otherwise → insert as literal text (Notion-style).
  - `extensions/d-block/dblock-node-view.tsx` — removed the <iframe-substring auto-conversion branch (and now-unused nodeContentLink memo). YouTube/Vimeo URL
  auto-embed branches remain and still produce allowlisted srcs.