### PR TITLE
fix: stop math showing "=Error" on click (disable evaluation)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.1.4",
+      "version": "4.1.5",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package/extensions/default-extension.ts
+++ b/package/extensions/default-extension.ts
@@ -464,7 +464,12 @@ export const defaultExtensions = ({
   SearchAndReplace,
   MathExtension.configure({
     addInlineMath: true,
-    evaluation: true,
+    // Math is notation here, not a calculator. With evaluation on, clicking a
+    // formula toggles an appended "=<result>", and the evaluator only handles
+    // plain arithmetic — so any symbolic math (\sum, \int, fractions, an
+    // empty-bound \sum_{123}^{}) shows "=Error" on click. Disable it so math
+    // just renders.
+    evaluation: false,
     delimiters: 'dollar',
     katexOptions: {
       throwOnError: false,


### PR DESCRIPTION
## Bug
Clicking inline LaTeX math appends **`=Error`** (e.g. `$\sum_{123}^{}$` → shows `=Error` on click).

## Root cause
The math extension (`@aarkue/tiptap-math-extension`) is configured with `evaluation: true`. That makes every formula a click-to-toggle "calculator": clicking reveals an appended `=<result>` computed by `evaluateExpression()`, which only handles **plain arithmetic**. For any symbolic math — `\sum`, `\int`, fractions, an empty-bound sum — it returns no result and the extension renders `resultSpan.innerText = "=Error"`.

So clicking essentially any real math notation shows `=Error`. (The extension author even left a `// Do not show if error occurs` comment — it's a known rough edge.)

The flag was carried over incidentally in the tiptap-v3 migration (#376); nothing in the app surfaces or relies on the evaluation/calculator feature.

## Fix
Set `evaluation: false`. With it off, the extension skips the whole click/result/error path — math just renders. No `=Error`, no hidden click-to-evaluate affordance.

**Trade-off:** removes the (undocumented, hidden) click-to-compute behavior, e.g. `$2+2$` → `=4`. Given it's incidental and the source of this bug across all symbolic math, that's the right call.

## Verification
Driven against the demo (headless Chromium): inserted `$\sum_{123}^{}$`, clicked it repeatedly — math renders correctly (`∑₁₂₃`), no `=Error`, no pointer/toggle affordance. `tsc`, lint, and full build clean.