### PR TITLE
feat: custom CSS support in document styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 # Editor
 .cursorrules
 
+# graphify (generated knowledge graph — local only)
+graphify-out/
+

--- a/demo/src/DocumentStylingPanel.tsx
+++ b/demo/src/DocumentStylingPanel.tsx
@@ -113,7 +113,7 @@ export const DocumentStylingPanel: React.FC<DocumentStylingPanelProps> = ({
     : {
         level: hasCssError ? ('error' as const) : ('warning' as const),
         message: hasCssError
-          ? 'Some CSS couldn’t be applied — check your syntax.'
+          ? 'Some CSS couldn’t be applied. Check your syntax.'
           : 'Some styles were removed for safety.',
       };
 
@@ -305,11 +305,7 @@ export const DocumentStylingPanel: React.FC<DocumentStylingPanelProps> = ({
             Custom CSS
           </label>
           <p className="text-xs text-slate-500 dark:text-slate-400">
-            Target elements directly — e.g.{' '}
-            <code className="font-mono">h1</code>,{' '}
-            <code className="font-mono">p</code>,{' '}
-            <code className="font-mono">blockquote</code>. Scoped to the document
-            automatically.
+            Add your own CSS to customize the appearance and layout of your doc.
           </p>
           <textarea
             id="custom-css-input"
@@ -317,7 +313,7 @@ export const DocumentStylingPanel: React.FC<DocumentStylingPanelProps> = ({
             onChange={(e) => handleStylingUpdate({ customCSS: e.target.value })}
             spellCheck={false}
             placeholder={
-              'h1 { letter-spacing: -0.02em }\np { line-height: 1.8 }'
+              'body { font-family: Georgia, serif }\nh1 { letter-spacing: -0.02em }'
             }
             className="w-full h-32 p-2 text-xs font-mono rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-100 resize-y focus:outline-none focus:border-blue-500"
           />

--- a/demo/src/DocumentStylingPanel.tsx
+++ b/demo/src/DocumentStylingPanel.tsx
@@ -279,6 +279,33 @@ export const DocumentStylingPanel: React.FC<DocumentStylingPanelProps> = ({
           </div>
         </div>
 
+        {/* Custom CSS */}
+        <div className="space-y-2">
+          <label
+            htmlFor="custom-css-input"
+            className="text-sm font-medium block text-slate-700 dark:text-slate-200"
+          >
+            Custom CSS
+          </label>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Target elements directly — e.g.{' '}
+            <code className="font-mono">h1</code>,{' '}
+            <code className="font-mono">p</code>,{' '}
+            <code className="font-mono">blockquote</code>. Scoped to the document
+            automatically.
+          </p>
+          <textarea
+            id="custom-css-input"
+            value={currentStyling.customCSS ?? ''}
+            onChange={(e) => handleStylingUpdate({ customCSS: e.target.value })}
+            spellCheck={false}
+            placeholder={
+              'h1 { letter-spacing: -0.02em }\np { line-height: 1.8 }'
+            }
+            className="w-full h-32 p-2 text-xs font-mono rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-100 resize-y focus:outline-none focus:border-blue-500"
+          />
+        </div>
+
         {/* Reset Button */}
         <div className="pt-4 border-t border-slate-200 dark:border-slate-600">
           <button

--- a/demo/src/DocumentStylingPanel.tsx
+++ b/demo/src/DocumentStylingPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { DocumentStyling, DocumentStylingValue } from '../../package/types';
+import { validateCustomCss } from '../../package/utils/sanitize-css';
 import cn from 'classnames';
 
 interface DocumentStylingPanelProps {
@@ -99,6 +100,10 @@ export const DocumentStylingPanel: React.FC<DocumentStylingPanelProps> = ({
   const handleStylingUpdate = (updates: Partial<DocumentStyling>) => {
     onStylingChange({ ...currentStyling, ...updates });
   };
+
+  // Non-blocking diagnostics for the Custom CSS box — what the sanitizer
+  // stripped/ignored (url(), position:fixed, breakout, syntax errors).
+  const cssDiagnostics = validateCustomCss(currentStyling.customCSS).diagnostics;
 
   return (
     <div className="fixed top-[108px] left-4 z-50 bg-gradient-to-br from-slate-50 to-white dark:from-slate-800 dark:to-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-2xl backdrop-blur-sm max-w-sm max-h-[calc(100vh-120px)] overflow-y-auto">
@@ -304,6 +309,24 @@ export const DocumentStylingPanel: React.FC<DocumentStylingPanelProps> = ({
             }
             className="w-full h-32 p-2 text-xs font-mono rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-100 resize-y focus:outline-none focus:border-blue-500"
           />
+          {cssDiagnostics.length > 0 && (
+            <ul className="space-y-1">
+              {cssDiagnostics.map((d) => (
+                <li
+                  key={d.message}
+                  className={cn(
+                    'text-xs flex gap-1.5 items-start',
+                    d.level === 'error'
+                      ? 'text-red-600 dark:text-red-400'
+                      : 'text-amber-600 dark:text-amber-500',
+                  )}
+                >
+                  <span aria-hidden>{d.level === 'error' ? '⛔' : '⚠️'}</span>
+                  <span>{d.message}</span>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
 
         {/* Reset Button */}

--- a/demo/src/DocumentStylingPanel.tsx
+++ b/demo/src/DocumentStylingPanel.tsx
@@ -101,9 +101,24 @@ export const DocumentStylingPanel: React.FC<DocumentStylingPanelProps> = ({
     onStylingChange({ ...currentStyling, ...updates });
   };
 
-  // Non-blocking diagnostics for the Custom CSS box — what the sanitizer
-  // stripped/ignored (url(), position:fixed, breakout, syntax errors).
+  // One general (non-blocking) message for the Custom CSS box. The sanitizer
+  // returns per-issue diagnostics; we collapse them to two neutral variants so
+  // the copy is never wrong: "removed for safety" (url()/@import/fixed/scope)
+  // vs "couldn't be applied" (a syntax error). Specific reasons stay available
+  // in the diagnostics array for the future if needed.
   const cssDiagnostics = validateCustomCss(currentStyling.customCSS).diagnostics;
+  const cssIssue =
+    cssDiagnostics.length === 0
+      ? null
+      : cssDiagnostics.some((d) => d.level === 'error')
+        ? {
+            level: 'error' as const,
+            message: 'Some CSS couldn’t be applied — check your syntax.',
+          }
+        : {
+            level: 'warning' as const,
+            message: 'Some styles were removed for safety.',
+          };
 
   return (
     <div className="fixed top-[108px] left-4 z-50 bg-gradient-to-br from-slate-50 to-white dark:from-slate-800 dark:to-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-2xl backdrop-blur-sm max-w-sm max-h-[calc(100vh-120px)] overflow-y-auto">
@@ -309,23 +324,18 @@ export const DocumentStylingPanel: React.FC<DocumentStylingPanelProps> = ({
             }
             className="w-full h-32 p-2 text-xs font-mono rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-800 dark:text-slate-100 resize-y focus:outline-none focus:border-blue-500"
           />
-          {cssDiagnostics.length > 0 && (
-            <ul className="space-y-1">
-              {cssDiagnostics.map((d) => (
-                <li
-                  key={d.message}
-                  className={cn(
-                    'text-xs flex gap-1.5 items-start',
-                    d.level === 'error'
-                      ? 'text-red-600 dark:text-red-400'
-                      : 'text-amber-600 dark:text-amber-500',
-                  )}
-                >
-                  <span aria-hidden>{d.level === 'error' ? '⛔' : '⚠️'}</span>
-                  <span>{d.message}</span>
-                </li>
-              ))}
-            </ul>
+          {cssIssue && (
+            <p
+              className={cn(
+                'text-xs flex gap-1.5 items-start',
+                cssIssue.level === 'error'
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-amber-600 dark:text-amber-500',
+              )}
+            >
+              <span aria-hidden>{cssIssue.level === 'error' ? '⛔' : '⚠️'}</span>
+              <span>{cssIssue.message}</span>
+            </p>
           )}
         </div>
 

--- a/demo/src/DocumentStylingPanel.tsx
+++ b/demo/src/DocumentStylingPanel.tsx
@@ -107,18 +107,15 @@ export const DocumentStylingPanel: React.FC<DocumentStylingPanelProps> = ({
   // vs "couldn't be applied" (a syntax error). Specific reasons stay available
   // in the diagnostics array for the future if needed.
   const cssDiagnostics = validateCustomCss(currentStyling.customCSS).diagnostics;
-  const cssIssue =
-    cssDiagnostics.length === 0
-      ? null
-      : cssDiagnostics.some((d) => d.level === 'error')
-        ? {
-            level: 'error' as const,
-            message: 'Some CSS couldn’t be applied — check your syntax.',
-          }
-        : {
-            level: 'warning' as const,
-            message: 'Some styles were removed for safety.',
-          };
+  const hasCssError = cssDiagnostics.some((d) => d.level === 'error');
+  const cssIssue = !cssDiagnostics.length
+    ? null
+    : {
+        level: hasCssError ? ('error' as const) : ('warning' as const),
+        message: hasCssError
+          ? 'Some CSS couldn’t be applied — check your syntax.'
+          : 'Some styles were removed for safety.',
+      };
 
   return (
     <div className="fixed top-[108px] left-4 z-50 bg-gradient-to-br from-slate-50 to-white dark:from-slate-800 dark:to-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6 shadow-2xl backdrop-blur-sm max-w-sm max-h-[calc(100vh-120px)] overflow-y-auto">

--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,14 @@ export { DdocExportModal } from './package/components/export-modal';
 export { useHeadlessEditor } from './package/hooks/use-headless-editor';
 export { useExportHeadlessEditorContent } from './package/hooks/use-export-headless-editor-content';
 export { mergeTabAwareYjsUpdates } from './package/components/tabs/utils/tab-utils';
+export {
+  validateCustomCss,
+  sanitizeCustomCss,
+} from './package/utils/sanitize-css';
+export type {
+  CssDiagnostic,
+  CssValidationResult,
+} from './package/utils/sanitize-css';
 export { buildVersionDiffSnapshot } from './package/components/tabs/utils/version-diff-snapshot';
 export type {
   DdocExportModalProps,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.1.11-patch-2",
+  "version": "4.1.11-patch-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.1.11-patch-2",
+      "version": "4.1.11-patch-3",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.1.11-patch-4",
+  "version": "4.1.11-patch-5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.1.11-patch-4",
+      "version": "4.1.11-patch-5",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.1.11-patch-1",
+  "version": "4.1.11-patch-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.1.11-patch-1",
+      "version": "4.1.11-patch-2",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.1.11-patch-5",
+  "version": "4.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.1.11-patch-5",
+      "version": "4.1.12",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.1.11-patch-3",
+  "version": "4.1.11-patch-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.1.11-patch-3",
+      "version": "4.1.11-patch-4",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.1.11",
+  "version": "4.1.11-patch-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.1.11",
+      "version": "4.1.11-patch-1",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.1.11-patch-3",
+  "version": "4.1.11-patch-4",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.1.11-patch-1",
+  "version": "4.1.11-patch-2",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.1.11-patch-2",
+  "version": "4.1.11-patch-3",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.1.11-patch-4",
+  "version": "4.1.11-patch-5",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.1.11",
+  "version": "4.1.11-patch-1",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.1.11-patch-5",
+  "version": "4.1.12",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package/components/split-view/split-view-css-accordion.tsx
+++ b/package/components/split-view/split-view-css-accordion.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+
+interface SplitViewCssAccordionProps {
+  /** The document's custom CSS (raw author selectors). */
+  customCSS?: string;
+}
+
+/**
+ * Split View LEFT pane: a collapsible, READ-ONLY view of the document's custom
+ * CSS, shown above the markdown source. Custom CSS is edited in the styling
+ * palette (the single source of truth), not in the markdown pane — this is a
+ * transparency affordance so the author can see what CSS is applied while in
+ * markdown mode. Renders nothing when there is no custom CSS.
+ */
+export const SplitViewCssAccordion = ({
+  customCSS,
+}: SplitViewCssAccordionProps) => {
+  const [open, setOpen] = useState(false);
+  const css = customCSS?.trim();
+  if (!css) return null;
+
+  return (
+    <div className="shrink-0 border-b color-border-default">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="w-full flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium color-text-secondary hover:color-bg-default-hover transition-all"
+      >
+        <ChevronRight
+          size={12}
+          className={`transition-transform ${open ? 'rotate-90' : ''}`}
+        />
+        <span>Custom CSS</span>
+        <span className="ml-auto text-[10px] opacity-70">
+          read-only · edit in Style panel
+        </span>
+      </button>
+      {open && (
+        <pre className="m-0 px-3 pb-2 text-[11px] leading-relaxed font-mono color-text-secondary whitespace-pre-wrap break-words max-h-40 overflow-auto select-text">
+          {css}
+        </pre>
+      )}
+    </div>
+  );
+};

--- a/package/components/split-view/split-view-markdown-pane.tsx
+++ b/package/components/split-view/split-view-markdown-pane.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, useCallback, useState } from 'react';
 import type { EditorView } from '@codemirror/view';
 import { IpfsImageUploadResponse } from '../../types';
+import { SplitViewCssAccordion } from './split-view-css-accordion';
 import './split-view.css';
 
 // Lazy chunks: CodeMirror only loads/instantiates when Split View opens.
@@ -13,6 +14,8 @@ interface SplitViewMarkdownPaneProps {
   /** Same uploader the editor uses — for the markdown toolbar's Image button. */
   ipfsImageUploadFn?: (file: File) => Promise<IpfsImageUploadResponse>;
   onError?: (error: string) => void;
+  /** Document custom CSS — shown read-only in a collapsible accordion. */
+  customCSS?: string;
   /** Sizing for the resizable split (flex-grow set by the draggable splitter). */
   style?: React.CSSProperties;
 }
@@ -28,6 +31,7 @@ export const SplitViewMarkdownPane = ({
   onMarkdownChange,
   ipfsImageUploadFn,
   onError,
+  customCSS,
   style,
 }: SplitViewMarkdownPaneProps) => {
   // Capture the CodeMirror view to drive the dedicated markdown toolbar.
@@ -48,6 +52,7 @@ export const SplitViewMarkdownPane = ({
           onError={onError}
         />
       </Suspense>
+      <SplitViewCssAccordion customCSS={customCSS} />
       <div className="flex-1 min-h-0 overflow-hidden">
         <Suspense
           fallback={

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -52,6 +52,7 @@ import {
   getResponsiveThemeTextColor,
   getThemeStyle,
 } from './utils/document-styling';
+import { sanitizeCustomCss } from './utils/sanitize-css';
 import { useFocusMode } from './hooks/use-focus-mode';
 import { FullScreenToolbar } from './components/fullscreen-toolbar';
 import { mergeTabAwareYjsUpdates } from './components/tabs/utils/tab-utils';
@@ -409,6 +410,14 @@ const DdocEditor = forwardRef(
       const storage = editor?.storage?.markdownPasteHandler;
       if (storage) storage.customCSS = documentStyling?.customCSS ?? '';
     }, [editor, documentStyling?.customCSS]);
+
+    // Sanitize + scope the author's custom CSS before injecting it (it reaches
+    // viewers of published docs, so it's untrusted). Returns '' on SSR; the
+    // client re-renders with the sanitized rule after hydration.
+    const safeCustomCss = useMemo(
+      () => sanitizeCustomCss(documentStyling?.customCSS),
+      [documentStyling?.customCSS],
+    );
 
     useImperativeHandle(
       ref,
@@ -1382,16 +1391,14 @@ const DdocEditor = forwardRef(
           }}
         >
           {/* Author's custom CSS escape hatch. The author writes bare selectors
-              (`h1 { … }`, `p { … }`); we wrap them in the content scope so CSS
-              nesting confines every rule to the document — it can't leak into
-              the toolbar or the host app's chrome. Applies live while editing,
-              in preview, and in the published view. */}
-          {documentStyling?.customCSS ? (
-            <style
-              dangerouslySetInnerHTML={{
-                __html: `.ProseMirror { ${documentStyling.customCSS} }`,
-              }}
-            />
+              (`h1 { … }`, `p { … }`); sanitizeCustomCss scopes every rule to the
+              document (`.ProseMirror { … }`) AND strips injection vectors —
+              breakout via `}`, url()/@import exfiltration, position:fixed
+              overlays, expression()/behavior. Custom CSS reaches viewers of a
+              published doc, so it is treated as untrusted input, not a trusted
+              stylesheet. Applies live while editing, in preview, and published. */}
+          {safeCustomCss ? (
+            <style dangerouslySetInnerHTML={{ __html: safeCustomCss }} />
           ) : null}
           <div
             id="editor-canvas"
@@ -1500,6 +1507,7 @@ const DdocEditor = forwardRef(
                     onMarkdownChange={onSplitViewMarkdownChange}
                     ipfsImageUploadFn={ipfsImageUploadFn}
                     onError={onError}
+                    customCSS={documentStyling?.customCSS}
                     style={{ flexGrow: splitRatio }}
                   />
                 )}

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -414,8 +414,13 @@ const DdocEditor = forwardRef(
     // Sanitize + scope the author's custom CSS before injecting it (it reaches
     // viewers of published docs, so it's untrusted). Returns '' on SSR; the
     // client re-renders with the sanitized rule after hydration.
+    // Scope with a DOUBLED class (`.ProseMirror.ProseMirror`) so author custom
+    // CSS reliably wins over the editor's own element/class defaults without
+    // needing !important. The editor styles links via `.ProseMirror
+    // .custom-text-link` (specificity 0,2,0), which would otherwise beat a
+    // plain author `a { … }` (0,1,1); doubling makes author rules 0,2,1.
     const safeCustomCss = useMemo(
-      () => sanitizeCustomCss(documentStyling?.customCSS),
+      () => sanitizeCustomCss(documentStyling?.customCSS, '.ProseMirror.ProseMirror'),
       [documentStyling?.customCSS],
     );
 

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -402,6 +402,14 @@ const DdocEditor = forwardRef(
       },
     });
 
+    // Mirror custom CSS into the markdown extension's storage so the
+    // exportMarkdownFile command can embed it as a <style> block (the export
+    // has no other access to documentStyling).
+    useEffect(() => {
+      const storage = editor?.storage?.markdownPasteHandler;
+      if (storage) storage.customCSS = documentStyling?.customCSS ?? '';
+    }, [editor, documentStyling?.customCSS]);
+
     useImperativeHandle(
       ref,
       () => ({
@@ -1373,6 +1381,18 @@ const DdocEditor = forwardRef(
                   : `calc(100dvh - 52px - ${footerHeight || '0px'})`,
           }}
         >
+          {/* Author's custom CSS escape hatch. The author writes bare selectors
+              (`h1 { … }`, `p { … }`); we wrap them in the content scope so CSS
+              nesting confines every rule to the document — it can't leak into
+              the toolbar or the host app's chrome. Applies live while editing,
+              in preview, and in the published view. */}
+          {documentStyling?.customCSS ? (
+            <style
+              dangerouslySetInnerHTML={{
+                __html: `.ProseMirror { ${documentStyling.customCSS} }`,
+              }}
+            />
+          ) : null}
           <div
             id="editor-canvas"
             onMouseDown={handleFocusModeMouseDown}

--- a/package/extensions/html-export/index.tsx
+++ b/package/extensions/html-export/index.tsx
@@ -6,6 +6,7 @@ import { getTemporaryEditor } from '../../utils/helpers';
 import { searchForSecureImageNodeAndEmbedImageContent } from '../mardown-paste-handler';
 import DOMPurify from 'dompurify';
 import { prettifyHtml } from '../../utils/prettify-html';
+import { sanitizeCustomCss } from '../../utils/sanitize-css';
 import {
   MERMAID_SVG_ATTRS,
   MERMAID_SVG_TAGS,
@@ -112,21 +113,18 @@ const HtmlExportExtension = (
               date: new Date().toISOString().split('T')[0], // YYYY-MM-DD
             };
 
-            // The document's custom CSS (author-supplied, bare selectors),
-            // injected AFTER sanitize (which runs on the body only) so the
-            // <style> block survives — making the HTML a self-contained, styled
-            // artifact.
-            const customCSS: string = (
-              editor.storage?.markdownPasteHandler?.customCSS || ''
-            ).trim();
-            // Scope to `body` (the export's document root) exactly as the editor
-            // scopes to `.ProseMirror`: bare declarations style the surface,
-            // nested selectors style the content. WITHOUT this wrapper a bare
-            // top-level declaration (e.g. `background: …`) is an invalid rule and
-            // the CSS parser swallows the following selectors into it, killing
-            // the whole block. Relies on native CSS nesting (modern browsers).
-            const styleTag = customCSS
-              ? `\n      <style>\n        body {\n${customCSS}\n        }\n      </style>`
+            // The document's custom CSS (author-supplied). sanitizeCustomCss
+            // scopes it to `body` (the export's document root, mirroring the
+            // editor's `.ProseMirror`) AND strips injection vectors — breakout,
+            // url()/@import exfiltration, position:fixed overlays. The returned
+            // string is already `body { … }`-wrapped and safe to embed. Injected
+            // AFTER DOMPurify (which sanitizes the body only), so it survives.
+            const styleTag = sanitizeCustomCss(
+              editor.storage?.markdownPasteHandler?.customCSS || '',
+              'body',
+            );
+            const styleBlock = styleTag
+              ? `\n      <style>\n${styleTag}\n      </style>`
               : '';
 
             // Create a clean HTML document (no classes/IDs); the only styling is
@@ -134,7 +132,7 @@ const HtmlExportExtension = (
             const htmlContent = `
   <html>
     <head>
-      <title>${metadata.title}</title>${styleTag}
+      <title>${metadata.title}</title>${styleBlock}
     </head>
     <body>
       ${cleanHtml}

--- a/package/extensions/html-export/index.tsx
+++ b/package/extensions/html-export/index.tsx
@@ -112,11 +112,29 @@ const HtmlExportExtension = (
               date: new Date().toISOString().split('T')[0], // YYYY-MM-DD
             };
 
-            // Create a clean HTML document without any classes, IDs, or styles
+            // The document's custom CSS (author-supplied, bare selectors),
+            // injected AFTER sanitize (which runs on the body only) so the
+            // <style> block survives — making the HTML a self-contained, styled
+            // artifact.
+            const customCSS: string = (
+              editor.storage?.markdownPasteHandler?.customCSS || ''
+            ).trim();
+            // Scope to `body` (the export's document root) exactly as the editor
+            // scopes to `.ProseMirror`: bare declarations style the surface,
+            // nested selectors style the content. WITHOUT this wrapper a bare
+            // top-level declaration (e.g. `background: …`) is an invalid rule and
+            // the CSS parser swallows the following selectors into it, killing
+            // the whole block. Relies on native CSS nesting (modern browsers).
+            const styleTag = customCSS
+              ? `\n      <style>\n        body {\n${customCSS}\n        }\n      </style>`
+              : '';
+
+            // Create a clean HTML document (no classes/IDs); the only styling is
+            // the author's custom CSS, when present.
             const htmlContent = `
   <html>
     <head>
-      <title>${metadata.title}</title>
+      <title>${metadata.title}</title>${styleTag}
     </head>
     <body>
       ${cleanHtml}

--- a/package/extensions/mardown-paste-handler/index.ts
+++ b/package/extensions/mardown-paste-handler/index.ts
@@ -15,6 +15,7 @@ import { toByteArray } from 'base64-js';
 import { inlineLoader } from '../../utils/inline-loader';
 import { IpfsImageFetchPayload, IpfsImageUploadResponse } from '../../types';
 import { isLikelyLatex } from '../../utils/is-likely-latex';
+import { sanitizeCustomCss } from '../../utils/sanitize-css';
 import { getTemporaryEditor } from '../../utils/helpers';
 import { resolveEditorColorVars } from '../../utils/colors';
 import {
@@ -838,17 +839,20 @@ const MarkdownPasteHandler = (
                 /<style\b[^>]*>[\s\S]*?<\/style>\s*/gi,
                 '',
               );
-              const customCSS: string = (
-                editor.storage?.markdownPasteHandler?.customCSS || ''
-              ).trim();
-              if (props?.includeStyles && customCSS) {
-                // Scope to `body` (the rendered document's root) exactly as the
-                // editor scopes to `.ProseMirror`: bare declarations style the
-                // surface, nested selectors style the content. WITHOUT the
-                // wrapper a bare top-level declaration is an invalid rule and the
-                // CSS parser swallows the following selectors into it. Relies on
-                // native CSS nesting (modern browsers).
-                markdown = `<style>\nbody {\n${customCSS}\n}\n</style>\n\n${markdown}`;
+              // sanitizeCustomCss scopes the author CSS to `body` (the rendered
+              // doc's root, mirroring the editor's `.ProseMirror`) AND strips
+              // injection vectors — breakout, url()/@import exfiltration,
+              // position:fixed overlays. The returned string is already
+              // `body { … }`-wrapped, so the downloaded .md is self-contained
+              // and safe to render on any html:true markdown renderer.
+              const safeCSS = props?.includeStyles
+                ? sanitizeCustomCss(
+                    editor.storage?.markdownPasteHandler?.customCSS || '',
+                    'body',
+                  )
+                : '';
+              if (safeCSS) {
+                markdown = `<style>\n${safeCSS}\n</style>\n\n${markdown}`;
               }
 
               const metadataEntries: Record<string, string> = {

--- a/package/extensions/mardown-paste-handler/index.ts
+++ b/package/extensions/mardown-paste-handler/index.ts
@@ -575,6 +575,9 @@ turndownService.addRule('linkDefinition', {
 
 // Define the command type
 declare module '@tiptap/core' {
+  interface Storage {
+    markdownPasteHandler: { customCSS: string };
+  }
   interface Commands {
     uploadMarkdownFile: {
       uploadMarkdownFile: (
@@ -609,6 +612,13 @@ const MarkdownPasteHandler = (
 ) =>
   Extension.create({
     name: 'markdownPasteHandler',
+
+    // The document's custom CSS, mirrored here by ddoc-editor so the
+    // exportMarkdownFile command can embed it as a <style> block — the export
+    // has no other access to documentStyling.
+    addStorage() {
+      return { customCSS: '' as string };
+    },
 
     addProseMirrorPlugins() {
       return [
@@ -817,6 +827,28 @@ const MarkdownPasteHandler = (
               } finally {
                 setMarkdownInlineStyles(false);
                 setResolveColorVars(false);
+              }
+
+              // Enforce the invariant: exactly one <style> block, and only the
+              // canonical custom CSS. Strip any stray <style> the content may
+              // carry (e.g. an old doc polluted before the import-side fix),
+              // then, in "with styles" mode, prepend the single custom-CSS block
+              // so the downloaded .md is self-contained and never duplicated.
+              markdown = markdown.replace(
+                /<style\b[^>]*>[\s\S]*?<\/style>\s*/gi,
+                '',
+              );
+              const customCSS: string = (
+                editor.storage?.markdownPasteHandler?.customCSS || ''
+              ).trim();
+              if (props?.includeStyles && customCSS) {
+                // Scope to `body` (the rendered document's root) exactly as the
+                // editor scopes to `.ProseMirror`: bare declarations style the
+                // surface, nested selectors style the content. WITHOUT the
+                // wrapper a bare top-level declaration is an invalid rule and the
+                // CSS parser swallows the following selectors into it. Relies on
+                // native CSS nesting (modern browsers).
+                markdown = `<style>\nbody {\n${customCSS}\n}\n</style>\n\n${markdown}`;
               }
 
               const metadataEntries: Record<string, string> = {
@@ -1106,6 +1138,16 @@ export async function handleMarkdownContent(
 ) {
   // Remove YAML frontmatter before parsing
   let cleanMarkdown = stripFrontmatter(content);
+
+  // Custom CSS is styling, never document content. Strip every <style> block
+  // so it can't leak into the doc — DOMPurify is inconsistent (it drops a
+  // leading multi-line block but keeps an inline/single-line one), which is how
+  // a stray <style> ends up as a text node and re-exports as a duplicate. The
+  // canonical block is handled separately (Split View seed / export prepend).
+  cleanMarkdown = cleanMarkdown.replace(
+    /<style\b[^>]*>[\s\S]*?<\/style>/gi,
+    '',
+  );
 
   // Protect formulas from being interpreted as markdown by escaping asterisks
   // Only escape asterisks that are clearly part of math expressions (e.g., 4*6, [1,2]*[3,4])

--- a/package/hooks/use-markdown-sync.ts
+++ b/package/hooks/use-markdown-sync.ts
@@ -25,6 +25,12 @@ interface UseMarkdownSyncArgs {
   onSeedError?: () => void;
 }
 
+// Custom CSS is edited in the styling palette, never in the markdown pane —
+// the pane is document content only. exportMarkdownFile embeds a `<style>`
+// block for downloads, so we strip a leading one from the seed to keep it out
+// of the on-screen pane. Matches the export format and trailing blank lines.
+const LEADING_STYLE_BLOCK = /^\s*<style>[\s\S]*?<\/style>\s*\n*/i;
+
 /**
  * Split View markdown sync — MVP (one-way: markdown → doc).
  *
@@ -85,6 +91,8 @@ export const useMarkdownSync = ({
         // re-embed automatically in handleMarkdownContent.)
         // replaceAll: replace the whole doc by range, atomically — never via
         // the live selection, which can move during an awaited image upload.
+        // Any <style> pasted into the pane is stripped in handleMarkdownContent
+        // (styling lives in the palette, never in doc content).
         await handleMarkdownContent(editor.view, value, ipfsImageUploadFn, {
           breaks: true,
           replaceAll: true,
@@ -138,9 +146,12 @@ export const useMarkdownSync = ({
           embedImages: false,
         });
         if (!cancelled && typeof md === 'string') {
-          // The export prepends YAML frontmatter (title/date) for file
-          // downloads; it's noise in the pane and import strips it anyway.
-          setMarkdown(stripFrontmatter(md));
+          // The export prepends YAML frontmatter (title/date) and — in
+          // "with styles" mode — a custom-CSS <style> block for downloads. Both
+          // are noise in the pane (styling is edited in the palette, not here),
+          // so strip them to show pure document content.
+          const body = stripFrontmatter(md).replace(LEADING_STYLE_BLOCK, '');
+          setMarkdown(body);
           seededRef.current = true;
         }
       } catch (error) {

--- a/package/types.ts
+++ b/package/types.ts
@@ -148,6 +148,18 @@ export interface DocumentStyling {
    * @example "portrait" | "landscape"
    */
   orientation?: 'portrait' | 'landscape';
+
+  /**
+   * Custom CSS
+   * @description The author's escape hatch for styling the document beyond the
+   * structured options above. Write BARE selectors (`h1 { … }`, `p { … }`,
+   * `blockquote { … }`) — they are auto-scoped to the document content, so rules
+   * can't leak into the toolbar or the host app. Bare top-level declarations
+   * (e.g. `background`, `font-family`) style the document surface itself.
+   * Applies live in the editor, in preview, and in exports (Markdown/HTML).
+   * @example "h1 { letter-spacing: -0.02em } p { line-height: 1.8 }"
+   */
+  customCSS?: string;
 }
 export interface DdocProps extends CommentAccountProps {
   /**

--- a/package/utils/sanitize-css.ts
+++ b/package/utils/sanitize-css.ts
@@ -1,9 +1,9 @@
 /**
- * Sanitize author-supplied custom CSS before it is injected into the document.
+ * Sanitize + validate author-supplied custom CSS before it is injected into the
+ * document.
  *
- * Custom CSS travels to VIEWERS of a published document, so a malicious author
- * could otherwise attack readers. The raw string is NOT a trusted stylesheet.
- * We defend against:
+ * Custom CSS travels to VIEWERS of a published document, so the raw string is
+ * NOT a trusted stylesheet. We defend against:
  *  - scope breakout: a `}` in the CSS escaping the `scope { … }` wrapper to
  *    style the whole app (toolbar, other content, security UI, overlays);
  *  - external resource loads / exfiltration: `url(…)` and `@import` (tracking
@@ -15,14 +15,27 @@
  * Strategy: wrap the raw CSS in `scope { … }` and parse it with the browser's
  * own CSS engine (no dependency, no regex parsing). A well-formed input yields
  * exactly ONE top-level rule whose selector is `scope`; a breakout produces
- * extra top-level rules with other selectors — we keep only the `scope` rule
- * and drop the rest. Dangerous declarations are stripped at every nesting
- * level. The kept rule is re-serialized by the engine, so the output is always
- * a valid, balanced stylesheet.
+ * extra top-level rules with other selectors — we keep only `scope` rules and
+ * drop the rest. Dangerous declarations are stripped at every nesting level.
+ * The kept rules are re-serialized by the engine, so the output is always a
+ * valid, balanced stylesheet.
  *
- * Returns '' when nothing safe remains, on a parse error, or when called
- * without a DOM (SSR) — the client re-runs it after hydration.
+ * The sanitizer knows exactly what it removed, so it also returns non-blocking
+ * `diagnostics` — the editing UI shows these so authors aren't left wondering
+ * why a rule silently vanished (CSS is forgiving; we warn, never block).
  */
+
+export interface CssDiagnostic {
+  level: 'warning' | 'error';
+  message: string;
+}
+
+export interface CssValidationResult {
+  /** Sanitized, scope-wrapped CSS, safe to inject. '' when nothing survives. */
+  css: string;
+  /** What was stripped/ignored, deduped. Empty when the CSS was fully clean. */
+  diagnostics: CssDiagnostic[];
+}
 
 // Any url(...) reference — we allow none (document images come through the
 // content pipeline, not CSS), so even data: URIs are dropped for simplicity.
@@ -30,41 +43,70 @@ const URL_REF = /url\(/i;
 // Legacy/script-ish value vectors.
 const DANGEROUS_VALUE = /expression\(|-moz-binding|behavior\s*:/i;
 
-const stripDeclarations = (style: CSSStyleDeclaration): void => {
+const MSG = {
+  url: 'url() and external resources aren’t allowed — they were removed.',
+  position:
+    'position: fixed and position: sticky aren’t allowed — they were removed.',
+  legacy: 'expression()/behavior aren’t allowed — they were removed.',
+  atImport: '@import isn’t allowed — it was removed.',
+  breakout:
+    'CSS is scoped to the document — rules targeting the whole page were ignored.',
+  unparseable: 'Couldn’t parse this CSS — check for a typo or unbalanced { }.',
+};
+
+const stripDeclarations = (
+  style: CSSStyleDeclaration,
+  reasons: Set<string>,
+): void => {
   // Iterate a snapshot — removeProperty mutates the live collection.
   for (const prop of Array.from(style)) {
     const name = prop.toLowerCase();
     const value = style.getPropertyValue(prop);
-    if (
-      URL_REF.test(value) ||
+    if (URL_REF.test(value)) {
+      style.removeProperty(prop);
+      reasons.add(MSG.url);
+    } else if (name === 'position' && /\b(fixed|sticky)\b/i.test(value)) {
+      style.removeProperty(prop);
+      reasons.add(MSG.position);
+    } else if (
       DANGEROUS_VALUE.test(value) ||
       name === 'behavior' ||
-      name === '-moz-binding' ||
-      (name === 'position' && /\b(fixed|sticky)\b/i.test(value))
+      name === '-moz-binding'
     ) {
       style.removeProperty(prop);
+      reasons.add(MSG.legacy);
     }
   }
 };
 
 // Recursively strip dangerous declarations from a rule and everything nested
 // inside it (nested style rules, @media/@supports blocks, …).
-const stripRule = (rule: CSSRule): void => {
+const stripRule = (rule: CSSRule, reasons: Set<string>): void => {
   const anyRule = rule as CSSRule & {
     style?: CSSStyleDeclaration;
     cssRules?: CSSRuleList;
   };
-  if (anyRule.style) stripDeclarations(anyRule.style);
+  if (anyRule.style) stripDeclarations(anyRule.style, reasons);
   if (anyRule.cssRules) {
-    for (const child of Array.from(anyRule.cssRules)) stripRule(child);
+    for (const child of Array.from(anyRule.cssRules)) stripRule(child, reasons);
   }
 };
 
-export const sanitizeCustomCss = (
+const isEmptyRule = (rule: CSSStyleRule): boolean =>
+  rule.style.length === 0 && rule.cssRules.length === 0;
+
+/**
+ * Sanitize AND report. Use this from the editing UI to surface diagnostics.
+ */
+export const validateCustomCss = (
   raw: string | undefined | null,
   scope = '.ProseMirror',
-): string => {
-  if (!raw || !raw.trim() || typeof document === 'undefined') return '';
+): CssValidationResult => {
+  if (!raw || !raw.trim() || typeof document === 'undefined') {
+    return { css: '', diagnostics: [] };
+  }
+
+  const reasons = new Set<string>();
 
   let sheet: CSSStyleSheet | null = null;
   try {
@@ -75,22 +117,62 @@ export const sanitizeCustomCss = (
     doc.head.appendChild(styleEl);
     sheet = styleEl.sheet;
   } catch {
-    return '';
+    return {
+      css: '',
+      diagnostics: [{ level: 'error', message: MSG.unparseable }],
+    };
   }
-  if (!sheet) return '';
+  if (!sheet) {
+    return {
+      css: '',
+      diagnostics: [{ level: 'error', message: MSG.unparseable }],
+    };
+  }
 
-  const kept: string[] = [];
+  // The parser silently drops @import that sits inside a style rule, so it
+  // never shows up as a rule — detect it from the raw text instead.
+  if (/@import\b/i.test(raw)) reasons.add(MSG.atImport);
+
+  const kept: CSSStyleRule[] = [];
+  let ignoredTopLevel = 0;
   for (const rule of Array.from(sheet.cssRules)) {
-    // Keep ONLY the single wrapper rule. Any other top-level rule is a breakout
-    // (or an at-rule like @import) and is dropped.
+    // Keep ONLY wrapper rules (selector === scope). A breakout produces extra
+    // top-level rules with other selectors → counted and dropped.
     if (
       typeof CSSStyleRule !== 'undefined' &&
       rule instanceof CSSStyleRule &&
       rule.selectorText === scope
     ) {
-      stripRule(rule);
-      kept.push(rule.cssText);
+      stripRule(rule, reasons);
+      kept.push(rule);
+    } else {
+      ignoredTopLevel += 1;
     }
   }
-  return kept.join('\n');
+  if (ignoredTopLevel > 0) reasons.add(MSG.breakout);
+
+  const css = kept
+    .filter((rule) => !isEmptyRule(rule))
+    .map((rule) => rule.cssText)
+    .join('\n');
+
+  const diagnostics: CssDiagnostic[] = Array.from(reasons).map((message) => ({
+    level: 'warning',
+    message,
+  }));
+  // Non-empty input that produced nothing, with no other explanation → syntax.
+  if (!css && reasons.size === 0) {
+    diagnostics.push({ level: 'error', message: MSG.unparseable });
+  }
+
+  return { css, diagnostics };
 };
+
+/**
+ * Sanitized CSS only — used at injection/export sinks that just need the safe
+ * string. Diagnostics are surfaced separately via validateCustomCss.
+ */
+export const sanitizeCustomCss = (
+  raw: string | undefined | null,
+  scope = '.ProseMirror',
+): string => validateCustomCss(raw, scope).css;

--- a/package/utils/sanitize-css.ts
+++ b/package/utils/sanitize-css.ts
@@ -1,28 +1,28 @@
 /**
- * Sanitize + validate author-supplied custom CSS before it is injected into the
- * document.
+ * Sanitize + scope + validate author-supplied custom CSS before it is injected
+ * into the document.
  *
- * Custom CSS travels to VIEWERS of a published document, so the raw string is
- * NOT a trusted stylesheet. We defend against:
- *  - scope breakout: a `}` in the CSS escaping the `scope { … }` wrapper to
- *    style the whole app (toolbar, other content, security UI, overlays);
- *  - external resource loads / exfiltration: `url(…)` and `@import` (tracking
- *    beacons, plus CSS attribute-selector data exfiltration);
- *  - clickjacking / UI redressing: `position: fixed | sticky` overlays that
- *    escape the document box and cover the viewport;
+ * Authors write **normal, full-page CSS** — `body { … }`, `html body h1 { … }`,
+ * `h1 { … }`, `* { … }` — the way they'd style any web page. We transparently
+ * scope every rule to the document so it can't leak into the app, AND we map the
+ * page-root selectors (`html`, `body`, `:root`) onto the document root so that
+ * `body { background: … }` styles the doc surface and `html body h1 { … }`
+ * styles the doc's headings. No `.ProseMirror` prefix, no learning curve.
+ *
+ * Because the raw string reaches VIEWERS of a published doc, it is untrusted.
+ * Every selector is force-scoped (so a `}` breakout is neutralised — the escaped
+ * rule is simply scoped too), and dangerous declarations are stripped:
+ *  - external resource loads / exfiltration: `url(…)`, `@import`;
+ *  - clickjacking / UI redressing: `position: fixed | sticky`;
  *  - legacy script vectors: `expression()`, `-moz-binding`, `behavior:`.
  *
- * Strategy: wrap the raw CSS in `scope { … }` and parse it with the browser's
- * own CSS engine (no dependency, no regex parsing). A well-formed input yields
- * exactly ONE top-level rule whose selector is `scope`; a breakout produces
- * extra top-level rules with other selectors — we keep only `scope` rules and
- * drop the rest. Dangerous declarations are stripped at every nesting level.
- * The kept rules are re-serialized by the engine, so the output is always a
- * valid, balanced stylesheet.
+ * We parse with the browser's own CSS engine (no dependency), rewrite each
+ * selector, strip dangerous declarations at every nesting level, and let the
+ * engine re-serialise — so the output is always a valid, balanced stylesheet.
  *
- * The sanitizer knows exactly what it removed, so it also returns non-blocking
- * `diagnostics` — the editing UI shows these so authors aren't left wondering
- * why a rule silently vanished (CSS is forgiving; we warn, never block).
+ * The sanitizer knows exactly what it removed, so it returns non-blocking
+ * `diagnostics`; the editing UI surfaces them (CSS is forgiving — we warn,
+ * never block).
  */
 
 export interface CssDiagnostic {
@@ -31,7 +31,7 @@ export interface CssDiagnostic {
 }
 
 export interface CssValidationResult {
-  /** Sanitized, scope-wrapped CSS, safe to inject. '' when nothing survives. */
+  /** Sanitized, scoped CSS, safe to inject. '' when nothing survives. */
   css: string;
   /** What was stripped/ignored, deduped. Empty when the CSS was fully clean. */
   diagnostics: CssDiagnostic[];
@@ -42,17 +42,54 @@ export interface CssValidationResult {
 const URL_REF = /url\(/i;
 // Legacy/script-ish value vectors.
 const DANGEROUS_VALUE = /expression\(|-moz-binding|behavior\s*:/i;
+// A leading page-root chain (html / body / :root, possibly combined) that we
+// map onto the document scope. Only matches a "complete" token (followed by
+// whitespace, a combinator, or end) so `body.dark` isn't mistaken for `body`.
+const ROOT_LEAD = /^\s*(?:(?:html|body|:root)(?=$|[\s>~+])\s*[>~+]?\s*)+/i;
 
 const MSG = {
-  url: 'url() and external resources aren’t allowed — they were removed.',
+  url: "url() and external resources aren't allowed, so they were removed.",
   position:
-    'position: fixed and position: sticky aren’t allowed — they were removed.',
-  legacy: 'expression()/behavior aren’t allowed — they were removed.',
-  atImport: '@import isn’t allowed — it was removed.',
-  breakout:
-    'CSS is scoped to the document — rules targeting the whole page were ignored.',
-  unparseable: 'Couldn’t parse this CSS — check for a typo or unbalanced { }.',
+    "position: fixed and position: sticky aren't allowed, so they were removed.",
+  legacy: "expression() and behavior aren't allowed, so they were removed.",
+  atImport: "@import isn't allowed, so it was removed.",
+  unparseable: "Couldn't parse this CSS. Check for a typo or unbalanced { }.",
 };
+
+// Split a comma-separated selector list at top level, respecting () and [].
+const splitSelectorList = (list: string): string[] => {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of list) {
+    if (ch === '(' || ch === '[') depth += 1;
+    else if (ch === ')' || ch === ']') depth = Math.max(0, depth - 1);
+    if (ch === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) parts.push(current);
+  return parts;
+};
+
+// Scope a single selector to `scope`, mapping a leading html/body/:root chain
+// onto the scope itself (so `body` → scope, `body h1` → `scope h1`).
+const scopeSelector = (selector: string, scope: string): string => {
+  const trimmed = selector.trim();
+  if (!trimmed) return '';
+  const remainder = trimmed.replace(ROOT_LEAD, '').trim();
+  if (!remainder) return scope; // `body`, `html body`, `:root` → the doc root
+  return `${scope} ${remainder}`;
+};
+
+const scopeSelectorList = (selectorText: string, scope: string): string =>
+  splitSelectorList(selectorText)
+    .map((s) => scopeSelector(s, scope))
+    .filter(Boolean)
+    .join(', ');
 
 const stripDeclarations = (
   style: CSSStyleDeclaration,
@@ -79,8 +116,9 @@ const stripDeclarations = (
   }
 };
 
-// Recursively strip dangerous declarations from a rule and everything nested
-// inside it (nested style rules, @media/@supports blocks, …).
+// Recursively strip dangerous declarations from a rule and everything nested in
+// it. Author-nested rules (`h1 { & span { … } }`) stay relative to their parent
+// — we don't re-scope them, only strip their declarations.
 const stripRule = (rule: CSSRule, reasons: Set<string>): void => {
   const anyRule = rule as CSSRule & {
     style?: CSSStyleDeclaration;
@@ -92,11 +130,25 @@ const stripRule = (rule: CSSRule, reasons: Set<string>): void => {
   }
 };
 
-const isEmptyRule = (rule: CSSStyleRule): boolean =>
-  rule.style.length === 0 && rule.cssRules.length === 0;
+// Scope a top-level style rule's selector and strip its (and nested) declarations.
+const scopeStyleRule = (
+  rule: CSSStyleRule,
+  scope: string,
+  reasons: Set<string>,
+): void => {
+  const scoped = scopeSelectorList(rule.selectorText, scope);
+  if (scoped) {
+    try {
+      rule.selectorText = scoped;
+    } catch {
+      /* leave as-is if the engine rejects it */
+    }
+  }
+  stripRule(rule, reasons);
+};
 
 /**
- * Sanitize AND report. Use this from the editing UI to surface diagnostics.
+ * Sanitize + scope AND report. Use this from the editing UI for diagnostics.
  */
 export const validateCustomCss = (
   raw: string | undefined | null,
@@ -113,7 +165,7 @@ export const validateCustomCss = (
     // Parse in a detached document so nothing applies to the live page.
     const doc = document.implementation.createHTMLDocument('');
     const styleEl = doc.createElement('style');
-    styleEl.textContent = `${scope} { ${raw} }`;
+    styleEl.textContent = raw;
     doc.head.appendChild(styleEl);
     sheet = styleEl.sheet;
   } catch {
@@ -129,33 +181,34 @@ export const validateCustomCss = (
     };
   }
 
-  // The parser silently drops @import that sits inside a style rule, so it
-  // never shows up as a rule — detect it from the raw text instead.
   if (/@import\b/i.test(raw)) reasons.add(MSG.atImport);
 
-  const kept: CSSStyleRule[] = [];
-  let ignoredTopLevel = 0;
+  const CssStyleRuleCtor =
+    typeof CSSStyleRule !== 'undefined' ? CSSStyleRule : null;
+  const CssGroupingCtors = [
+    typeof CSSMediaRule !== 'undefined' ? CSSMediaRule : null,
+    typeof CSSSupportsRule !== 'undefined' ? CSSSupportsRule : null,
+  ].filter(Boolean) as Array<typeof CSSMediaRule>;
+
+  const kept: string[] = [];
   for (const rule of Array.from(sheet.cssRules)) {
-    // Keep ONLY wrapper rules (selector === scope). A breakout produces extra
-    // top-level rules with other selectors → counted and dropped.
-    if (
-      typeof CSSStyleRule !== 'undefined' &&
-      rule instanceof CSSStyleRule &&
-      rule.selectorText === scope
-    ) {
-      stripRule(rule, reasons);
-      kept.push(rule);
-    } else {
-      ignoredTopLevel += 1;
+    if (CssStyleRuleCtor && rule instanceof CssStyleRuleCtor) {
+      scopeStyleRule(rule, scope, reasons);
+      kept.push(rule.cssText);
+    } else if (CssGroupingCtors.some((ctor) => rule instanceof ctor)) {
+      // @media / @supports — scope the inner style rules, keep the wrapper.
+      const group = rule as CSSMediaRule;
+      for (const inner of Array.from(group.cssRules)) {
+        if (CssStyleRuleCtor && inner instanceof CssStyleRuleCtor) {
+          scopeStyleRule(inner, scope, reasons);
+        }
+      }
+      kept.push(group.cssText);
     }
+    // Everything else (@import, @font-face, @keyframes, …) is dropped.
   }
-  if (ignoredTopLevel > 0) reasons.add(MSG.breakout);
 
-  const css = kept
-    .filter((rule) => !isEmptyRule(rule))
-    .map((rule) => rule.cssText)
-    .join('\n');
-
+  const css = kept.join('\n');
   const diagnostics: CssDiagnostic[] = Array.from(reasons).map((message) => ({
     level: 'warning',
     message,
@@ -169,8 +222,8 @@ export const validateCustomCss = (
 };
 
 /**
- * Sanitized CSS only — used at injection/export sinks that just need the safe
- * string. Diagnostics are surfaced separately via validateCustomCss.
+ * Sanitized + scoped CSS only — used at injection/export sinks that just need
+ * the safe string. Diagnostics are surfaced separately via validateCustomCss.
  */
 export const sanitizeCustomCss = (
   raw: string | undefined | null,

--- a/package/utils/sanitize-css.ts
+++ b/package/utils/sanitize-css.ts
@@ -42,10 +42,14 @@ export interface CssValidationResult {
 const URL_REF = /url\(/i;
 // Legacy/script-ish value vectors.
 const DANGEROUS_VALUE = /expression\(|-moz-binding|behavior\s*:/i;
-// A leading page-root chain (html / body / :root, possibly combined) that we
-// map onto the document scope. Only matches a "complete" token (followed by
-// whitespace, a combinator, or end) so `body.dark` isn't mistaken for `body`.
-const ROOT_LEAD = /^\s*(?:(?:html|body|:root)(?=$|[\s>~+])\s*[>~+]?\s*)+/i;
+// A leading document-root chain that we map onto the doc scope so full-page
+// CSS "just works": the page roots (html / body / :root) and `.markdown-body`
+// — the github-markdown content wrapper many blogs (incl. Vitalik's) use as
+// their content root, equivalent to our `.ProseMirror`. Only matches a
+// "complete" token (followed by whitespace, a combinator, or end) so
+// `body.dark` / `.markdown-body-foo` aren't mistaken for the root token.
+const ROOT_LEAD =
+  /^\s*(?:(?:html|body|:root|\.markdown-body)(?=$|[\s>~+])\s*[>~+]?\s*)+/i;
 
 const MSG = {
   url: "url() and external resources aren't allowed, so they were removed.",

--- a/package/utils/sanitize-css.ts
+++ b/package/utils/sanitize-css.ts
@@ -1,0 +1,96 @@
+/**
+ * Sanitize author-supplied custom CSS before it is injected into the document.
+ *
+ * Custom CSS travels to VIEWERS of a published document, so a malicious author
+ * could otherwise attack readers. The raw string is NOT a trusted stylesheet.
+ * We defend against:
+ *  - scope breakout: a `}` in the CSS escaping the `scope { … }` wrapper to
+ *    style the whole app (toolbar, other content, security UI, overlays);
+ *  - external resource loads / exfiltration: `url(…)` and `@import` (tracking
+ *    beacons, plus CSS attribute-selector data exfiltration);
+ *  - clickjacking / UI redressing: `position: fixed | sticky` overlays that
+ *    escape the document box and cover the viewport;
+ *  - legacy script vectors: `expression()`, `-moz-binding`, `behavior:`.
+ *
+ * Strategy: wrap the raw CSS in `scope { … }` and parse it with the browser's
+ * own CSS engine (no dependency, no regex parsing). A well-formed input yields
+ * exactly ONE top-level rule whose selector is `scope`; a breakout produces
+ * extra top-level rules with other selectors — we keep only the `scope` rule
+ * and drop the rest. Dangerous declarations are stripped at every nesting
+ * level. The kept rule is re-serialized by the engine, so the output is always
+ * a valid, balanced stylesheet.
+ *
+ * Returns '' when nothing safe remains, on a parse error, or when called
+ * without a DOM (SSR) — the client re-runs it after hydration.
+ */
+
+// Any url(...) reference — we allow none (document images come through the
+// content pipeline, not CSS), so even data: URIs are dropped for simplicity.
+const URL_REF = /url\(/i;
+// Legacy/script-ish value vectors.
+const DANGEROUS_VALUE = /expression\(|-moz-binding|behavior\s*:/i;
+
+const stripDeclarations = (style: CSSStyleDeclaration): void => {
+  // Iterate a snapshot — removeProperty mutates the live collection.
+  for (const prop of Array.from(style)) {
+    const name = prop.toLowerCase();
+    const value = style.getPropertyValue(prop);
+    if (
+      URL_REF.test(value) ||
+      DANGEROUS_VALUE.test(value) ||
+      name === 'behavior' ||
+      name === '-moz-binding' ||
+      (name === 'position' && /\b(fixed|sticky)\b/i.test(value))
+    ) {
+      style.removeProperty(prop);
+    }
+  }
+};
+
+// Recursively strip dangerous declarations from a rule and everything nested
+// inside it (nested style rules, @media/@supports blocks, …).
+const stripRule = (rule: CSSRule): void => {
+  const anyRule = rule as CSSRule & {
+    style?: CSSStyleDeclaration;
+    cssRules?: CSSRuleList;
+  };
+  if (anyRule.style) stripDeclarations(anyRule.style);
+  if (anyRule.cssRules) {
+    for (const child of Array.from(anyRule.cssRules)) stripRule(child);
+  }
+};
+
+export const sanitizeCustomCss = (
+  raw: string | undefined | null,
+  scope = '.ProseMirror',
+): string => {
+  if (!raw || !raw.trim() || typeof document === 'undefined') return '';
+
+  let sheet: CSSStyleSheet | null = null;
+  try {
+    // Parse in a detached document so nothing applies to the live page.
+    const doc = document.implementation.createHTMLDocument('');
+    const styleEl = doc.createElement('style');
+    styleEl.textContent = `${scope} { ${raw} }`;
+    doc.head.appendChild(styleEl);
+    sheet = styleEl.sheet;
+  } catch {
+    return '';
+  }
+  if (!sheet) return '';
+
+  const kept: string[] = [];
+  for (const rule of Array.from(sheet.cssRules)) {
+    // Keep ONLY the single wrapper rule. Any other top-level rule is a breakout
+    // (or an at-rule like @import) and is dropped.
+    if (
+      typeof CSSStyleRule !== 'undefined' &&
+      rule instanceof CSSStyleRule &&
+      rule.selectorText === scope
+    ) {
+      stripRule(rule);
+      kept.push(rule.cssText);
+    }
+  }
+  return kept.join('\n');
+};

--- a/package/utils/sanitize-css.ts
+++ b/package/utils/sanitize-css.ts
@@ -134,21 +134,55 @@ const stripRule = (rule: CSSRule, reasons: Set<string>): void => {
   }
 };
 
-// Scope a top-level style rule's selector and strip its (and nested) declarations.
-const scopeStyleRule = (
-  rule: CSSStyleRule,
+const isStyleRule = (rule: CSSRule): boolean =>
+  typeof CSSStyleRule !== 'undefined' && rule instanceof CSSStyleRule;
+
+// @media / @supports — conditional groups that can wrap (and nest) style rules.
+const isGroupingRule = (rule: CSSRule): boolean =>
+  (typeof CSSMediaRule !== 'undefined' && rule instanceof CSSMediaRule) ||
+  (typeof CSSSupportsRule !== 'undefined' && rule instanceof CSSSupportsRule);
+
+// Sanitize a rule tree in place, returning true if the rule should be KEPT.
+//  - style rule: scope its selector (DROP if unscopable — never keep an
+//    unscoped selector) and strip dangerous declarations (this rule + its
+//    author-nested, relative rules).
+//  - grouping rule (@media / @supports, at ANY nesting depth): recurse and
+//    delete any child that must be dropped, so nested rules can't escape
+//    scoping or smuggle url()/@import/position:fixed past the sanitizer.
+//  - anything else (@import, @font-face, @keyframes, @layer, @container, …):
+//    drop. Keeping only known-safe rules is the security-critical default.
+const sanitizeRule = (
+  rule: CSSRule,
   scope: string,
   reasons: Set<string>,
-): void => {
-  const scoped = scopeSelectorList(rule.selectorText, scope);
-  if (scoped) {
+): boolean => {
+  if (isStyleRule(rule)) {
+    const styleRule = rule as CSSStyleRule;
+    const scoped = scopeSelectorList(styleRule.selectorText, scope);
+    if (!scoped) return false;
     try {
-      rule.selectorText = scoped;
+      styleRule.selectorText = scoped;
     } catch {
-      /* leave as-is if the engine rejects it */
+      return false;
     }
+    stripRule(styleRule, reasons);
+    return true;
   }
-  stripRule(rule, reasons);
+  if (isGroupingRule(rule)) {
+    const group = rule as CSSGroupingRule;
+    // Iterate backwards so deleteRule() doesn't shift the indices ahead of us.
+    for (let i = group.cssRules.length - 1; i >= 0; i -= 1) {
+      if (!sanitizeRule(group.cssRules[i], scope, reasons)) {
+        try {
+          group.deleteRule(i);
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+    return true;
+  }
+  return false;
 };
 
 /**
@@ -187,29 +221,9 @@ export const validateCustomCss = (
 
   if (/@import\b/i.test(raw)) reasons.add(MSG.atImport);
 
-  const CssStyleRuleCtor =
-    typeof CSSStyleRule !== 'undefined' ? CSSStyleRule : null;
-  const CssGroupingCtors = [
-    typeof CSSMediaRule !== 'undefined' ? CSSMediaRule : null,
-    typeof CSSSupportsRule !== 'undefined' ? CSSSupportsRule : null,
-  ].filter(Boolean) as Array<typeof CSSMediaRule>;
-
   const kept: string[] = [];
   for (const rule of Array.from(sheet.cssRules)) {
-    if (CssStyleRuleCtor && rule instanceof CssStyleRuleCtor) {
-      scopeStyleRule(rule, scope, reasons);
-      kept.push(rule.cssText);
-    } else if (CssGroupingCtors.some((ctor) => rule instanceof ctor)) {
-      // @media / @supports — scope the inner style rules, keep the wrapper.
-      const group = rule as CSSMediaRule;
-      for (const inner of Array.from(group.cssRules)) {
-        if (CssStyleRuleCtor && inner instanceof CssStyleRuleCtor) {
-          scopeStyleRule(inner, scope, reasons);
-        }
-      }
-      kept.push(group.cssText);
-    }
-    // Everything else (@import, @font-face, @keyframes, …) is dropped.
+    if (sanitizeRule(rule, scope, reasons)) kept.push(rule.cssText);
   }
 
   const css = kept.join('\n');


### PR DESCRIPTION
## What

Adds **Custom CSS** to the editor — an author escape hatch for styling a document with their own CSS. Power-user request from Vitalik (publishes styled posts on ddocs). Paired with ddocs.new PR fileverse/ddocs.new#1032.

Authors write **bare selectors** (`h1 { … }`, `p { … }`) — no `.ProseMirror` prefix. The editor auto-scopes them to the document; bare top-level declarations (`background`, `font-family`, …) style the document surface.

## API

One field on the existing `DocumentStyling`, consumer-owned and edited via the consumer's styling panel — consistent with every other styling field (no new callback):

```ts
documentStyling: { customCSS?: string }
```

Also exports `validateCustomCss(raw)` / `sanitizeCustomCss(raw)` + `CssDiagnostic` types for consumers.

## How it works

- **Live inject** — a scoped `<style>` (`.ProseMirror { … }`) in the editor render; applies in editor, preview, and the published/viewer render (same component).
- **Exports** — Markdown ("export with CSS") and HTML embed the CSS wrapped in `body { … }` so it renders in the standalone file.
- **Invariant** — `<style>` is styling, never document content: import strips all `<style>`; the Split View source pane stays content-only; the CSS shows in a **collapsed, read-only accordion** above the source instead.

## 🔒 Security — custom CSS is untrusted (it reaches viewers of published docs)

`sanitizeCustomCss` parses the CSS with the browser's own engine (no dependency), keeps only rules scoped to the document, and strips injection vectors. Three vulnerabilities were confirmed via PoC and closed:

| Attack | Result |
|---|---|
| Scope breakout (`}` escapes the wrapper → style the whole app) | ✅ blocked |
| `url()` / `@import` exfiltration (beacons, DOM data leak) | ✅ stripped |
| `position: fixed` overlay (clickjacking) | ✅ stripped |

Also strips `expression()` / `-moz-binding` / `behavior`. Applied at every sink (live inject + both exports).

## Validation / errors

`validateCustomCss` returns non-blocking diagnostics for what was stripped/ignored. Surfaced in the styling panel as **one general message** (two neutral variants): *"Some styles were removed for safety"* (url/@import/fixed/scope) vs *"Some CSS couldn't be applied — check your syntax"* (a syntax error).

## Files

- `package/utils/sanitize-css.ts` — sanitizer + `validateCustomCss` (new)
- `package/ddoc-editor.tsx` — scoped `<style>` inject (sanitized) + export storage mirror + accordion prop
- `package/extensions/html-export/index.tsx` — `body { }`-scoped `<style>` in `<head>`
- `package/extensions/mardown-paste-handler/index.ts` — export prepend + import/export `<style>` strip + storage
- `package/hooks/use-markdown-sync.ts` — Split View pane stays content-only
- `package/components/split-view/split-view-css-accordion.tsx` — read-only CSS view (new)
- `index.ts` — export `validateCustomCss` / `sanitizeCustomCss` / types
- `demo/src/DocumentStylingPanel.tsx` — Custom CSS input + one general message

## Notes

- Exports use native CSS nesting (`body { h1 { … } }`) — nested selectors need a modern browser; bare top-level declarations still apply everywhere.
- Published as pre-release **`4.1.11-patch-1`** for QA (tested via the ddocs.new preview). Real release TBD.

## Test plan

- [ ] Styling panel → `h1 { color: crimson }` → restyles live, no leak into toolbar
- [ ] Complex CSS (vars, gradients, `background-clip: text`, nested `@media`) renders; no diagnostics
- [ ] Malicious CSS (breakout / `url()` / `position:fixed`) is neutralized and shows the "removed for safety" message
- [ ] Export MD-with-CSS / HTML → open file → styled and self-contained
- [ ] Split View shows document content only; CSS appears in the read-only accordion
