### PR TITLE
feat(slides): image beside text, slide numbers, and presenter font scaling

### DIFF
--- a/package/components/presentation-mode/presentation-mode.tsx
+++ b/package/components/presentation-mode/presentation-mode.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  useRef,
+  CSSProperties,
+} from 'react';
 import { Editor, EditorContent } from '@tiptap/react';
 import {
   AnimatedLoader,
@@ -8,13 +15,12 @@ import {
   Tooltip,
 } from '@fileverse/ui';
 import { EditingProvider } from '../../hooks/use-editing-context';
-import { convertToMarkdown } from '../../utils/md-to-slides';
+import { buildSlidesFromDoc } from '../../utils/doc-to-slides';
 import { handlePrint } from '../../utils/handle-print';
 import { PreviewPanel } from './preview-panel';
 import { cn } from '@fileverse/ui';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, useAnimationControls } from 'framer-motion';
 import copy from 'copy-to-clipboard';
-import { convertMarkdownToHTML } from '../../utils/md-to-html';
 import { useResponsive } from '../../utils/responsive';
 import { IpfsImageFetchPayload, DdocProps, ThemeKey } from '../../types';
 import { dedupeResolvedExtensions } from '../../utils/helpers';
@@ -47,6 +53,43 @@ interface PresentationModeProps {
   fetchV1ImageFn?: (url: string) => Promise<ArrayBuffer | undefined>;
   theme?: ThemeKey;
 }
+
+/**
+ * Font scaling multiplies the presentation stylesheet's sizes via the
+ * `--slide-font-scale` custom property, so every element keeps its relative
+ * proportions instead of each one needing its own override.
+ */
+const FONT_SCALE_MIN = 0.6;
+const FONT_SCALE_MAX = 1.8;
+const FONT_SCALE_STEP = 0.1;
+
+const clampFontScale = (scale: number) =>
+  Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MIN, Number(scale.toFixed(2))));
+
+const SlideNumber = ({
+  current,
+  total,
+  isFullscreen,
+}: {
+  current: number;
+  total: number;
+  isFullscreen: boolean;
+}) => {
+  if (!total) return null;
+
+  return (
+    <div
+      className={cn(
+        'absolute z-40 select-none pointer-events-none text-helper-text-sm',
+        isFullscreen
+          ? 'bottom-6 right-8 color-utility-overlay color-text-inverse rounded-full px-3 py-1'
+          : 'bottom-4 right-6 color-text-secondary',
+      )}
+    >
+      {current} / {total}
+    </div>
+  );
+};
 
 const SlideContent = ({
   content,
@@ -112,8 +155,11 @@ const SlideContent = ({
   return (
     <EditorContent
       editor={editor}
+      // `w-full h-full` matches the markup the fullscreen path used before the
+      // two render paths were unified. Without it the container is a flex item
+      // that shrinks to its content.
       className={cn('presentation-mode', {
-        fullscreen: isFullscreen,
+        'fullscreen w-full h-full': isFullscreen,
       })}
       style={editorStyles}
       onTouchStart={onTouchStart}
@@ -150,9 +196,38 @@ export const PresentationMode = ({
   const [touchStart, setTouchStart] = useState<number | null>(null);
   const [touchEnd, setTouchEnd] = useState<number | null>(null);
   const minSwipeDistance = 50;
-  const [slideDirection, setSlideDirection] = useState<'forward' | 'backward'>(
-    'forward',
-  );
+  // Direction is only read when the slide-change animation fires, so a ref
+  // keeps it out of the render cycle and out of the effect's dependencies.
+  const slideDirectionRef = useRef<'forward' | 'backward'>('forward');
+  const [fontScale, setFontScale] = useState(1);
+  const slideAnimation = useAnimationControls();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // The document editor stays mounted behind this overlay and keeps DOM focus,
+  // so every keystroke meant for navigation was also being typed into the
+  // document. Surrender focus once the deck opens.
+  useEffect(() => {
+    editor.commands.blur();
+    (document.activeElement as HTMLElement | null)?.blur();
+  }, [editor]);
+
+  const adjustFontScale = useCallback((delta: number) => {
+    setFontScale((previous) => clampFontScale(previous + delta));
+  }, []);
+
+  // Replays the enter transition on each slide change without remounting the
+  // editor that renders the slide.
+  useEffect(() => {
+    slideAnimation.set({
+      opacity: 0,
+      x: slideDirectionRef.current === 'forward' ? 50 : -50,
+    });
+    slideAnimation.start({
+      opacity: 1,
+      x: 0,
+      transition: { duration: 0.2 },
+    });
+  }, [currentSlide, slideAnimation]);
 
   const themeCanvasBackground = getThemeStyle(
     documentStyling?.canvasBackground,
@@ -171,14 +246,16 @@ export const PresentationMode = ({
             // The presentation editor reuses the source editor's extension
             // instances. In a shared/viewer context the editor is in suggestion
             // mode, where suggestionTracking's filterTransaction blocks every
-            // doc-changing transaction — including the setContent that loads each
-            // slide. That left the active slide empty while the deck (rendered
-            // via dangerouslySetInnerHTML) still showed content. The presentation
+            // doc-changing transaction — including the setContent that loads
+            // each slide, which would leave every slide blank. The presentation
             // editor only renders slides read-only, so it never needs tracking.
             'suggestionTracking',
           ].includes(b.name),
       ),
-      editable: !isPreviewMode,
+      // Slides are a read-only view of the document. Left editable, the
+      // navigation shortcuts double as text input — pressing `f` to go
+      // fullscreen also types an "f" into the slide.
+      editable: false,
     });
   }, [isPreviewMode]);
   const handlePresentationMode = useCallback(async () => {
@@ -197,62 +274,25 @@ export const PresentationMode = ({
     }
 
     setIsLoading(true);
-    const markdown = await convertToMarkdown(
-      editor,
-      ipfsImageFetchFn,
-      fetchV1ImageFn,
-    );
 
-    // First convert markdown to HTML with proper page breaks
-    const html = convertMarkdownToHTML(markdown, {
-      preserveNewlines: true,
-      sanitize: true,
-      maxCharsPerSlide: 1000,
-      maxWordsPerSlide: 250,
-      maxLinesPerSlide: 7,
-    });
-    // Create a temporary div to properly parse the HTML
-    const tempDiv = document.createElement('div');
-    tempDiv.innerHTML = html;
+    try {
+      // Slides are derived straight from the document nodes. The previous
+      // doc -> Markdown -> HTML route silently dropped everything Markdown
+      // cannot express, most visibly multi-column blocks and font sizes.
+      const slideArray = await buildSlidesFromDoc(editor, {
+        ipfsImageFetchFn,
+        fetchV1ImageFn,
+        fontScale,
+      });
 
-    // Find all page breaks and split content
-    const slideArray: string[] = [];
-    let currentSlideContent: Node[] = [];
-
-    // Iterate through all nodes
-    tempDiv.childNodes.forEach((node) => {
-      if (
-        node instanceof HTMLElement &&
-        node.getAttribute('data-type') === 'page-break' &&
-        node.getAttribute('data-page-break') === 'true'
-      ) {
-        // When we hit a page break, save the current slide content
-        if (currentSlideContent.length > 0) {
-          const slideDiv = document.createElement('div');
-          currentSlideContent.forEach((n) =>
-            slideDiv.appendChild(n.cloneNode(true)),
-          );
-          slideArray.push(slideDiv.innerHTML);
-          currentSlideContent = [];
-        }
-      } else {
-        currentSlideContent.push(node.cloneNode(true));
-      }
-    });
-
-    // Don't forget to add the last slide
-    if (currentSlideContent.length > 0) {
-      const slideDiv = document.createElement('div');
-      currentSlideContent.forEach((n) =>
-        slideDiv.appendChild(n.cloneNode(true)),
-      );
-      slideArray.push(slideDiv.innerHTML);
+      setSlides(slideArray);
+    } catch (error) {
+      // Without this the loader spins forever and the failure is invisible.
+      console.error('Failed to build slides from document', error);
+      onError?.('Could not build slides from this document');
+    } finally {
+      setIsLoading(false);
     }
-
-    // Filter out empty slides and set the state
-    setSlides(slideArray.filter((slide) => slide.trim().length > 0));
-
-    setIsLoading(false);
   }, [isPreviewMode, editor.state.doc]);
   // Add check for empty editor
   useEffect(() => {
@@ -299,6 +339,18 @@ export const PresentationMode = ({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      // Yield to a comment box or similar field *inside* the deck, but not to
+      // the document editor sitting behind the overlay — keystrokes there are
+      // navigation, not typing.
+      const target = e.target as HTMLElement | null;
+      const isTextEntry =
+        target?.isContentEditable ||
+        ['INPUT', 'TEXTAREA', 'SELECT'].includes(target?.tagName ?? '');
+
+      if (isTextEntry && target && containerRef.current?.contains(target)) {
+        return;
+      }
+
       if (
         e.key === 'ArrowRight' ||
         e.key === 'ArrowDown' ||
@@ -306,18 +358,27 @@ export const PresentationMode = ({
       ) {
         e.preventDefault();
         e.stopPropagation();
-        setSlideDirection('forward');
+        slideDirectionRef.current = 'forward';
         setCurrentSlide((prev) => Math.min(prev + 1, slides.length - 1));
       } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
-        setSlideDirection('backward');
+        slideDirectionRef.current = 'backward';
         setCurrentSlide((prev) => Math.max(prev - 1, 0));
       } else if (e.key === 'Escape') {
         !isPreviewMode && onClose();
       } else if (e.key === 'f' || e.key === 'F') {
         toggleFullscreen();
+      } else if (e.key === '+' || e.key === '=') {
+        e.preventDefault();
+        adjustFontScale(FONT_SCALE_STEP);
+      } else if (e.key === '-' || e.key === '_') {
+        e.preventDefault();
+        adjustFontScale(-FONT_SCALE_STEP);
+      } else if (e.key === '0') {
+        e.preventDefault();
+        setFontScale(1);
       }
     },
-    [slides.length, onClose, toggleFullscreen],
+    [slides.length, onClose, toggleFullscreen, adjustFontScale],
   );
 
   useEffect(() => {
@@ -356,11 +417,11 @@ export const PresentationMode = ({
     const isRightSwipe = distance < -minSwipeDistance;
 
     if (isLeftSwipe) {
-      setSlideDirection('forward');
+      slideDirectionRef.current = 'forward';
       setCurrentSlide((prev) => Math.min(prev + 1, slides.length - 1));
     }
     if (isRightSwipe) {
-      setSlideDirection('backward');
+      slideDirectionRef.current = 'backward';
       setCurrentSlide((prev) => Math.max(prev - 1, 0));
     }
   }, [touchStart, touchEnd, slides.length, minSwipeDistance]);
@@ -395,6 +456,7 @@ export const PresentationMode = ({
 
   return (
     <div
+      ref={containerRef}
       className={cn(
         'fixed inset-0 color-bg-secondary flex z-50',
         isNativeMobile ? 'flex-col' : 'flex-col xl:flex-row',
@@ -442,6 +504,34 @@ export const PresentationMode = ({
             )}
             <div className="flex justify-center items-center gap-2">
               {renderThemeToggle?.()}
+              <div className="hidden md:flex items-center">
+                <Tooltip text="Decrease text size (-)" sideOffset={10}>
+                  <IconButton
+                    variant="ghost"
+                    icon="AArrowDown"
+                    size="md"
+                    disabled={fontScale <= FONT_SCALE_MIN}
+                    onClick={() => adjustFontScale(-FONT_SCALE_STEP)}
+                  />
+                </Tooltip>
+                <Tooltip text="Reset text size (0)" sideOffset={10}>
+                  <button
+                    onClick={() => setFontScale(1)}
+                    className="text-helper-text-sm color-text-secondary min-w-[3rem] px-1 py-1 rounded hover:color-bg-default-hover"
+                  >
+                    {Math.round(fontScale * 100)}%
+                  </button>
+                </Tooltip>
+                <Tooltip text="Increase text size (+)" sideOffset={10}>
+                  <IconButton
+                    variant="ghost"
+                    icon="AArrowUp"
+                    size="md"
+                    disabled={fontScale >= FONT_SCALE_MAX}
+                    onClick={() => adjustFontScale(FONT_SCALE_STEP)}
+                  />
+                </Tooltip>
+              </div>
               {!isPreviewMode && (
                 <Tooltip text="Download" sideOffset={10}>
                   <IconButton
@@ -526,33 +616,19 @@ export const PresentationMode = ({
             }}
           >
             <EditingProvider isPreviewMode={true} isPresentationMode={true}>
-              {isFullscreen ? (
-                <AnimatePresence mode="wait">
-                  <motion.div
-                    key={currentSlide}
-                    initial={{
-                      opacity: 0,
-                      x: slideDirection === 'forward' ? 50 : -50,
-                    }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{
-                      opacity: 0,
-                      x: slideDirection === 'forward' ? -50 : 50,
-                    }}
-                    transition={{ duration: 0.2 }}
-                  >
-                    <div
-                      className={cn(
-                        'presentation-mode fullscreen w-full h-full',
-                      )}
-                      dangerouslySetInnerHTML={{ __html: slides[currentSlide] }}
-                      onTouchStart={onTouchStart}
-                      onTouchMove={onTouchMove}
-                      onTouchEnd={onTouchEnd}
-                    />
-                  </motion.div>
-                </AnimatePresence>
-              ) : (
+              {/*
+                Both windowed and fullscreen render through the editor. They
+                used to diverge — fullscreen injected raw HTML — which meant
+                custom nodes could render in one and not the other. The wrapper
+                is animated via controls rather than remounted, because
+                EditorContent owns the editor's DOM node and re-parenting it on
+                every slide change is what made the two paths drift apart.
+              */}
+              <motion.div
+                animate={slideAnimation}
+                className="w-full h-full"
+                style={{ '--slide-font-scale': fontScale } as CSSProperties}
+              >
                 <SlideContent
                   content={slides[currentSlide]}
                   editor={presentationEditor}
@@ -563,8 +639,14 @@ export const PresentationMode = ({
                   documentStyling={documentStyling}
                   theme={theme}
                 />
-              )}
+              </motion.div>
             </EditingProvider>
+
+            <SlideNumber
+              current={currentSlide + 1}
+              total={slides.length}
+              isFullscreen={isFullscreen}
+            />
           </div>
         </div>
 
@@ -578,22 +660,17 @@ export const PresentationMode = ({
           </div>
         )}
 
+        {/* The slide counter that used to live here now renders for every
+            viewport via SlideNumber. */}
         {isFullscreen && isNativeMobile && (
-          <>
-            <div className="fixed top-2 right-4 z-50">
-              <IconButton
-                variant="ghost"
-                onClick={toggleFullscreen}
-                icon="X"
-                size="md"
-              />
-            </div>
-            <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2 color-utility-overlay px-3 py-1 rounded">
-              <span className="color-text-default">
-                {currentSlide + 1} / {slides.length}
-              </span>
-            </div>
-          </>
+          <div className="fixed top-2 right-4 z-50">
+            <IconButton
+              variant="ghost"
+              onClick={toggleFullscreen}
+              icon="X"
+              size="md"
+            />
+          </div>
         )}
       </div>
     </div>

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -572,6 +572,41 @@ const DdocEditor = forwardRef(
       commentDrawerOpen && setCommentDrawerOpen?.(false);
     };
 
+    // Mod-Alt-P opens the deck; presentation mode already owns Escape to leave
+    // it. This cannot live in the TipTap keymap because entering presentation
+    // mode is React state rather than an editor command.
+    useEffect(() => {
+      const handlePresentationShortcut = (event: KeyboardEvent) => {
+        const isModifier = navigator.platform.includes('Mac')
+          ? event.metaKey
+          : event.ctrlKey;
+
+        // `code` rather than `key`: Option-P emits "π" on macOS, so matching
+        // on the character would never fire there.
+        if (!isModifier || !event.altKey || event.code !== 'KeyP') return;
+
+        // Suppress the browser's own Ctrl/Cmd-P print binding.
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (isPresentationMode) return;
+
+        setIsPresentationMode?.(true);
+        commentDrawerOpen && setCommentDrawerOpen?.(false);
+      };
+
+      // Capture phase: the print shortcut has to be cancelled before anything
+      // else in the page gets a chance to act on the event.
+      window.addEventListener('keydown', handlePresentationShortcut, true);
+      return () =>
+        window.removeEventListener('keydown', handlePresentationShortcut, true);
+    }, [
+      isPresentationMode,
+      commentDrawerOpen,
+      setIsPresentationMode,
+      setCommentDrawerOpen,
+    ]);
+
     useEffect(() => {
       if (!editor) return;
       if (isNativeMobile) {

--- a/package/extensions/font-size/font-size.ts
+++ b/package/extensions/font-size/font-size.ts
@@ -43,6 +43,30 @@ export const FontSize = Extension.create({
         },
       },
       {
+        // A list marker is sized by its <li>, but the size lives on the mark
+        // or paragraph inside it, so a resized item ended up with a marker
+        // that no longer matched its own text. Carrying the size on the item
+        // lets the native marker follow it. Nothing sets this during editing —
+        // it defaults to null and is applied when building slides — so normal
+        // document output is unchanged.
+        types: ['listItem'],
+        attributes: {
+          fontSize: {
+            default: null,
+            parseHTML: (element) =>
+              element.style.fontSize?.replace(/['"]+/g, '') || null,
+            renderHTML: (attributes) => {
+              if (!attributes.fontSize) {
+                return {};
+              }
+              return {
+                style: `font-size: ${attributes.fontSize}`,
+              };
+            },
+          },
+        } as Attributes,
+      },
+      {
         types: this.options.types,
         attributes: {
           fontSize: {

--- a/package/styles/editor.css
+++ b/package/styles/editor.css
@@ -814,18 +814,31 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
     outline: 2px solid transparent;
     outline-offset: 2px;
 
+    /* Type and spacing are set proportionally to the 1080x608 stage, matching
+       the ratios the fullscreen stylesheet already uses (fullscreen sets body
+       text at ~1.6% of stage width; this block used to set it at ~2.2%). The
+       previous values were document styling — an 82px heading and 24px
+       paragraph gaps on a 608px-tall slide left room for barely a few lines,
+       so slides split with obvious space to spare and the windowed preview
+       looked nothing like the deck being presented. */
     h1 {
-      font-size: 5.125rem;
+      font-size: calc(var(--slide-font-scale, 1) * 2.25rem);
+      line-height: 1.2;
+      margin: 0 0 0.75rem;
       font-weight: 700;
     }
 
     h2 {
-      font-size: 2.5rem;
+      font-size: calc(var(--slide-font-scale, 1) * 1.6875rem);
+      line-height: 1.2;
+      margin: 0 0 0.75rem;
       font-weight: 700;
     }
 
     h3 {
-      font-size: 1.5rem;
+      font-size: calc(var(--slide-font-scale, 1) * 1.125rem);
+      line-height: 1.2;
+      margin: 0 0 0.75rem;
       font-weight: 700;
     }
 
@@ -840,12 +853,29 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
       object-fit: contain;
     }
 
+    /* Inside a column the image is one half of a layout rather than the
+       subject of the slide: it fills the column and keeps its own shape,
+       instead of being capped at 32rem and letterboxed into 16/9. */
+    [data-type='column'] img {
+      max-width: 100%;
+      aspect-ratio: auto;
+      object-fit: contain;
+    }
+
+    /* Columns are a deliberate side-by-side layout, so centre the two halves
+       against each other rather than leaving them top-aligned. */
+    [data-type='columns'] {
+      align-items: center;
+      gap: 1.5rem;
+    }
+
     p {
-      line-height: 36px;
-      font-size: 1.5rem;
+      /* Unitless so it tracks font-size, and with it the font scale. */
+      line-height: 1.5;
+      font-size: calc(var(--slide-font-scale, 1) * 1.0625rem);
       font-weight: 400;
-      margin-top: 0.75rem;
-      margin-bottom: 0.75rem;
+      margin-top: 0.375rem;
+      margin-bottom: 0.375rem;
 
       &:first-child {
         margin-top: 0;
@@ -865,8 +895,8 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
     }
 
     & > p {
-      margin-top: 1.5rem;
-      margin-bottom: 1.5rem;
+      margin-top: 0.375rem;
+      margin-bottom: 0.375rem;
 
       &:first-child {
         margin-top: 0;
@@ -878,13 +908,14 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
     }
 
     & > * + * {
-      margin-top: 1rem;
-      margin-bottom: 1rem;
+      margin-top: 0.375rem;
+      margin-bottom: 0.375rem;
     }
 
     ol,
     ul {
-      font-size: 1.5rem;
+      font-size: calc(var(--slide-font-scale, 1) * 1.0625rem);
+      line-height: 1.5;
     }
 
     ul[data-type='taskList'],
@@ -1080,6 +1111,16 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
     max-width: 100vw;
     align-items: start;
 
+    /* Slide content is rendered by the editor, so it arrives wrapped in a
+       single .ProseMirror element rather than as loose blocks. As a lone flex
+       item under `align-items: start` it would shrink to its content width,
+       collapsing column grids to one character per line and taking
+       full-width images down with them. */
+    > .ProseMirror {
+      width: 100%;
+      align-self: stretch;
+    }
+
     @media (max-width: 640px) {
       padding-top: max(env(safe-area-inset-top), 15vh);
       touch-action: pan-y pinch-zoom;
@@ -1088,21 +1129,21 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
     }
 
     h1 {
-      font-size: min(5vw, 64px);
+      font-size: calc(var(--slide-font-scale, 1) * min(5vw, 64px));
       line-height: 1.2;
       margin: 0 0 2vh;
       font-weight: 700;
     }
 
     h2 {
-      font-size: min(3vw, 48px);
+      font-size: calc(var(--slide-font-scale, 1) * min(3vw, 48px));
       line-height: 1.2;
       margin: 0 0 2vh;
       font-weight: 700;
     }
 
     h3 {
-      font-size: min(2vw, 32px);
+      font-size: calc(var(--slide-font-scale, 1) * min(2vw, 32px));
       line-height: 1.2;
       margin: 0 0 2vh;
       font-weight: 700;
@@ -1127,7 +1168,7 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
     p,
     ul,
     ol {
-      font-size: min(2vw, 30.72px);
+      font-size: calc(var(--slide-font-scale, 1) * min(2vw, 30.72px));
       line-height: 1.5;
       margin: 1vh 0;
       max-width: 80vw;
@@ -1174,7 +1215,7 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
     .task-list-item {
       list-style-type: none;
       margin: 0.5rem 0;
-      font-size: min(2vw, 30.72px);
+      font-size: calc(var(--slide-font-scale, 1) * min(2vw, 30.72px));
       line-height: 1.5;
 
       input[type='checkbox'] {
@@ -1212,14 +1253,14 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
       padding: 1rem;
 
       code {
-        font-size: min(1.5vw, 23.04px);
+        font-size: calc(var(--slide-font-scale, 1) * min(1.5vw, 23.04px));
         line-height: 1.5;
         background: transparent !important;
       }
     }
 
     code {
-      font-size: min(1.5vw, 18px);
+      font-size: calc(var(--slide-font-scale, 1) * min(1.5vw, 18px));
       background: hsla(var(--color-bg-tertiary));
       padding: 2px 6px;
       border-radius: 4px;
@@ -1247,7 +1288,7 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
       td {
         padding: 12px;
         border: 1px solid hsla(var(--color-border-default));
-        font-size: min(1.5vw, 23.04px) !important;
+        font-size: calc(var(--slide-font-scale, 1) * min(1.5vw, 23.04px)) !important;
       }
 
       th {
@@ -1260,19 +1301,19 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
       padding: 5vh 5vw;
 
       h1 {
-        font-size: min(8vw, 42px);
+        font-size: calc(var(--slide-font-scale, 1) * min(8vw, 42px));
       }
       h2 {
-        font-size: min(6vw, 32px);
+        font-size: calc(var(--slide-font-scale, 1) * min(6vw, 32px));
       }
       h3 {
-        font-size: min(5vw, 24px);
+        font-size: calc(var(--slide-font-scale, 1) * min(5vw, 24px));
       }
 
       p,
       ul,
       ol {
-        font-size: min(4vw, 18px);
+        font-size: calc(var(--slide-font-scale, 1) * min(4vw, 18px));
         max-width: 90vw;
       }
 
@@ -1287,13 +1328,13 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
         th,
         td {
           padding: 8px;
-          font-size: min(3.5vw, 16px);
+          font-size: calc(var(--slide-font-scale, 1) * min(3.5vw, 16px));
         }
       }
 
       pre code,
       code {
-        font-size: min(3.5vw, 16px);
+        font-size: calc(var(--slide-font-scale, 1) * min(3.5vw, 16px));
       }
     }
   }

--- a/package/styles/editor.css
+++ b/package/styles/editor.css
@@ -918,6 +918,43 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
       line-height: 1.5;
     }
 
+    /* Keep list text on the same line as its marker; see the matching rule in
+       the fullscreen block. */
+    li > p {
+      margin: 0;
+    }
+
+    /*
+     * A native ::marker takes its size from the <li>, while the text takes
+     * its size from the mark or paragraph inside it — so an item with an
+     * explicit font size got a marker that no longer matched its own text,
+     * increasingly visibly as the presenter font scale went up.
+     *
+     * The size is copied onto the list item itself when slides are built (see
+     * matchListMarkersToText), which the schema now carries, so these rules
+     * can stay as plain native markers.
+     *
+     * They live in the shared .ProseMirror block and so apply in fullscreen
+     * too; the fullscreen block only adjusts spacing.
+     */
+    ul:not([data-type='taskList']) {
+      list-style-type: disc;
+      padding-left: 2rem;
+
+      li {
+        list-style-type: inherit;
+      }
+    }
+
+    ol {
+      list-style-type: decimal;
+      padding-left: 2rem;
+
+      li {
+        display: list-item;
+      }
+    }
+
     ul[data-type='taskList'],
     li[data-type='taskItem'] {
       list-style: none !important;
@@ -1149,6 +1186,14 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
       font-weight: 700;
     }
 
+    /* A list item wraps its text in a paragraph, which would otherwise take
+       the block-level `p` margin. The marker stays anchored to the top of the
+       item, so that margin drops the text below its own bullet — visibly so
+       here, where the margin is viewport-relative. */
+    li > p {
+      margin: 0;
+    }
+
     blockquote {
       padding-left: 1rem;
       font-style: italic;
@@ -1183,32 +1228,24 @@ ul[data-type='taskList'] li[data-checked='true'] > div > p > span {
       margin-top: 1rem;
     }
 
+    /* Markers are drawn by the shared .ProseMirror rules so they inherit each
+       item's own font size; this block only sets spacing. `data-tight`
+       describes spacing, not nesting depth — it previously switched the marker
+       to a hollow circle, which made a top-level tight list read as a nested
+       one and disagreed with the windowed view. */
     ul:not([data-type='taskList']) {
-      list-style-type: disc;
-      padding-left: 2rem;
       margin: 1vh 0;
 
       &[data-tight='true'] {
         margin: 0;
-        list-style-type: circle;
         > li {
           margin: 0;
           padding: 0;
-          list-style-type: circle !important;
         }
       }
 
       li {
-        list-style-type: inherit;
         margin: 0.5vh 0;
-      }
-    }
-
-    ol {
-      list-style-type: decimal;
-      padding-left: 2rem;
-      li {
-        display: list-item;
       }
     }
 

--- a/package/utils/doc-to-slides.test.ts
+++ b/package/utils/doc-to-slides.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Editor } from '@tiptap/react';
 import { JSONContent } from '@tiptap/core';
-import { splitDocIntoSlides, isSoloMediaSlide } from './doc-to-slides';
+import {
+  splitDocIntoSlides,
+  isSoloMediaSlide,
+  scaleInlineFontSizes,
+  matchListMarkersToText,
+} from './doc-to-slides';
 // Same extension assembly the headless editor uses, so custom nodes
 // (dBlock, columns, pageBreak) are registered and the documents below are
 // validated against the real schema rather than hand-rolled JSON.
@@ -221,6 +226,160 @@ describe('splitDocIntoSlides', () => {
     // slide. Summing the columns would wrongly split it.
     const slides = splitDocIntoSlides(doc, { maxLinesPerSlide: 4 });
     expect(slides).toHaveLength(1);
+  });
+});
+
+describe('matchListMarkersToText', () => {
+  const listItem = (text: JSONContent): JSONContent => ({
+    type: 'listItem',
+    content: [{ type: 'paragraph', content: [text] }],
+  });
+
+  // A native marker is sized by its <li>, but the size lives on the mark
+  // inside it, so a resized item kept a base-size bullet.
+  it('copies a size carried by a textStyle mark onto the item', () => {
+    const result = matchListMarkersToText({
+      type: 'bulletList',
+      content: [
+        listItem({
+          type: 'text',
+          text: 'big',
+          marks: [{ type: 'textStyle', attrs: { fontSize: '30px' } }],
+        }),
+      ],
+    });
+
+    expect(result.content?.[0].attrs?.fontSize).toBe('30px');
+  });
+
+  it('copies a size carried as a paragraph attribute', () => {
+    const result = matchListMarkersToText({
+      type: 'bulletList',
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'paragraph',
+              attrs: { fontSize: '24px' },
+              content: [{ type: 'text', text: 'big' }],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.content?.[0].attrs?.fontSize).toBe('24px');
+  });
+
+  it('leaves an item with no explicit size untouched', () => {
+    const result = matchListMarkersToText({
+      type: 'bulletList',
+      content: [listItem({ type: 'text', text: 'plain' })],
+    });
+
+    expect(result.content?.[0].attrs?.fontSize).toBeUndefined();
+  });
+
+  it('sizes each item independently', () => {
+    const result = matchListMarkersToText({
+      type: 'bulletList',
+      content: [
+        listItem({
+          type: 'text',
+          text: 'small',
+          marks: [{ type: 'textStyle', attrs: { fontSize: '12px' } }],
+        }),
+        listItem({
+          type: 'text',
+          text: 'large',
+          marks: [{ type: 'textStyle', attrs: { fontSize: '40px' } }],
+        }),
+      ],
+    });
+
+    expect(result.content?.[0].attrs?.fontSize).toBe('12px');
+    expect(result.content?.[1].attrs?.fontSize).toBe('40px');
+  });
+
+  it('reaches items nested inside another list', () => {
+    const result = matchListMarkersToText({
+      type: 'bulletList',
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            {
+              type: 'bulletList',
+              content: [
+                listItem({
+                  type: 'text',
+                  text: 'nested',
+                  marks: [{ type: 'textStyle', attrs: { fontSize: '18px' } }],
+                }),
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    const nested = result.content?.[0].content?.[0].content?.[0];
+    expect(nested?.attrs?.fontSize).toBe('18px');
+  });
+
+  it('preserves content and other node types', () => {
+    const doc: JSONContent = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'before' }] },
+        {
+          type: 'bulletList',
+          content: [listItem({ type: 'text', text: 'item' })],
+        },
+      ],
+    };
+
+    expect(JSON.stringify(matchListMarkersToText(doc))).toContain('before');
+    expect(JSON.stringify(matchListMarkersToText(doc))).toContain('item');
+  });
+});
+
+describe('scaleInlineFontSizes', () => {
+  // Inline font-size beats any stylesheet rule, so explicitly-sized text used
+  // to ignore the presenter font scale while everything around it responded.
+  it('routes an explicit size through the scale variable', () => {
+    expect(scaleInlineFontSizes('<p style="font-size: 20px">big</p>')).toBe(
+      '<p style="font-size: calc(var(--slide-font-scale, 1) * 20px)">big</p>',
+    );
+  });
+
+  it.each(['px', 'rem', 'em', 'pt'])('handles %s units', (unit) => {
+    expect(
+      scaleInlineFontSizes(`<span style="font-size:1.5${unit}">x</span>`),
+    ).toBe(
+      `<span style="font-size: calc(var(--slide-font-scale, 1) * 1.5${unit})">x</span>`,
+    );
+  });
+
+  it('scales every occurrence, not just the first', () => {
+    const scaled = scaleInlineFontSizes(
+      '<p style="font-size: 12px">a</p><p style="font-size: 30px">b</p>',
+    );
+
+    expect(scaled).toContain('* 12px)');
+    expect(scaled).toContain('* 30px)');
+  });
+
+  // Running twice must not nest calc() inside calc().
+  it('is idempotent', () => {
+    const once = scaleInlineFontSizes('<p style="font-size: 20px">x</p>');
+    expect(scaleInlineFontSizes(once)).toBe(once);
+  });
+
+  it('leaves markup without an inline size untouched', () => {
+    const html = '<p>plain</p><ul><li>item</li></ul>';
+    expect(scaleInlineFontSizes(html)).toBe(html);
   });
 });
 

--- a/package/utils/doc-to-slides.test.ts
+++ b/package/utils/doc-to-slides.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Editor } from '@tiptap/react';
+import { JSONContent } from '@tiptap/core';
+import { splitDocIntoSlides, isSoloMediaSlide } from './doc-to-slides';
+// Same extension assembly the headless editor uses, so custom nodes
+// (dBlock, columns, pageBreak) are registered and the documents below are
+// validated against the real schema rather than hand-rolled JSON.
+import { getHeadlessExtensions } from '../hooks/use-headless-editor';
+
+/** Collect all text on a slide, for order-independent content assertions. */
+const slideText = (slide: JSONContent): string => {
+  const walk = (node?: JSONContent): string => {
+    if (!node) return '';
+    if (node.type === 'text') return node.text ?? '';
+    return (node.content ?? []).map(walk).join(' ');
+  };
+  return walk(slide).replace(/\s+/g, ' ').trim();
+};
+
+/** Depth-first search for a node type anywhere in a slide. */
+const hasNodeType = (slide: JSONContent, type: string): boolean => {
+  const walk = (node?: JSONContent): boolean => {
+    if (!node) return false;
+    if (node.type === type) return true;
+    return (node.content ?? []).some(walk);
+  };
+  return walk(slide);
+};
+
+describe('splitDocIntoSlides', () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = new Editor({ extensions: getHeadlessExtensions() });
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  /** Round-trips content through the editor so it conforms to the schema. */
+  const docFrom = (content: string | JSONContent): JSONContent => {
+    editor.commands.setContent(content);
+    return editor.getJSON();
+  };
+
+  // Titles used to be stranded on a slide of their own even when the content
+  // after them plainly fitted alongside.
+  it('keeps a heading together with the content that follows it', () => {
+    const slides = splitDocIntoSlides(
+      docFrom('<h1>Title</h1><p>Body copy</p>'),
+    );
+
+    expect(slides).toHaveLength(1);
+    expect(slideText(slides[0])).toBe('Title Body copy');
+  });
+
+  it('starts a new slide at a heading', () => {
+    const slides = splitDocIntoSlides(
+      docFrom('<p>Trailing text</p><h1>Title</h1><p>Body copy</p>'),
+    );
+
+    expect(slides).toHaveLength(2);
+    expect(slideText(slides[0])).toBe('Trailing text');
+    expect(slideText(slides[1])).toBe('Title Body copy');
+  });
+
+  it('leaves splitting to measurement when overflow limits are disabled', () => {
+    const paragraphs = Array.from(
+      { length: 30 },
+      (_, i) => `<p>Paragraph number ${i}</p>`,
+    ).join('');
+
+    const slides = splitDocIntoSlides(docFrom(paragraphs), {
+      applyOverflowLimits: false,
+    });
+
+    // No structural breaks in the document, so it stays a single slide for
+    // the measurement pass to divide against the real stage.
+    expect(slides).toHaveLength(1);
+  });
+
+  it('starts a new slide at each H2 and keeps the heading on it', () => {
+    const slides = splitDocIntoSlides(
+      docFrom('<h2>One</h2><p>First</p><h2>Two</h2><p>Second</p>'),
+    );
+
+    expect(slides).toHaveLength(2);
+    expect(slideText(slides[0])).toBe('One First');
+    expect(slideText(slides[1])).toBe('Two Second');
+  });
+
+  it('breaks on an explicit page break without rendering the break itself', () => {
+    const slides = splitDocIntoSlides(
+      docFrom(
+        '<p>Before</p><div data-type="page-break" data-page-break="true"></div><p>After</p>',
+      ),
+    );
+
+    expect(slides).toHaveLength(2);
+    expect(slideText(slides[0])).toBe('Before');
+    expect(slideText(slides[1])).toBe('After');
+    expect(slides.some((slide) => hasNodeType(slide, 'pageBreak'))).toBe(false);
+  });
+
+  it('breaks a long run of paragraphs once it overflows the slide', () => {
+    const paragraphs = Array.from(
+      { length: 12 },
+      (_, i) => `<p>Paragraph number ${i}</p>`,
+    ).join('');
+
+    const slides = splitDocIntoSlides(docFrom(paragraphs), {
+      maxLinesPerSlide: 4,
+    });
+
+    expect(slides.length).toBeGreaterThan(1);
+    // Nothing may be dropped on the way to the stage.
+    const allText = slides.map(slideText).join(' ');
+    for (let i = 0; i < 12; i++) {
+      expect(allText).toContain(`Paragraph number ${i}`);
+    }
+  });
+
+  it('never emits an empty slide', () => {
+    const slides = splitDocIntoSlides(
+      docFrom(
+        '<div data-type="page-break" data-page-break="true"></div><p>Only</p><div data-type="page-break" data-page-break="true"></div>',
+      ),
+    );
+
+    expect(slides).toHaveLength(1);
+    expect(slideText(slides[0])).toBe('Only');
+  });
+
+  // The reason this module exists: the Markdown pipeline flattens a columns
+  // block into sequential paragraphs, which is what makes "image left, text
+  // right" impossible on a slide today.
+  it('preserves a multi-column block instead of flattening it', () => {
+    const doc = docFrom({
+      type: 'doc',
+      content: [
+        {
+          type: 'dBlock',
+          content: [
+            {
+              type: 'columns',
+              content: [
+                {
+                  type: 'column',
+                  content: [
+                    {
+                      type: 'dBlock',
+                      content: [
+                        {
+                          type: 'paragraph',
+                          content: [{ type: 'text', text: 'Left side' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: 'column',
+                  content: [
+                    {
+                      type: 'dBlock',
+                      content: [
+                        {
+                          type: 'paragraph',
+                          content: [{ type: 'text', text: 'Right side' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    // Guard: if the schema rejected the structure the assertion below would
+    // pass vacuously, so confirm the source document really has columns.
+    expect(hasNodeType(doc, 'columns')).toBe(true);
+
+    const slides = splitDocIntoSlides(doc);
+
+    expect(slides).toHaveLength(1);
+    expect(hasNodeType(slides[0], 'columns')).toBe(true);
+    expect(hasNodeType(slides[0], 'column')).toBe(true);
+    expect(slideText(slides[0])).toContain('Left side');
+    expect(slideText(slides[0])).toContain('Right side');
+  });
+
+  it('measures a columns block by its tallest column, not the sum', () => {
+    const column = (lines: number) => ({
+      type: 'column',
+      content: Array.from({ length: lines }, (_, i) => ({
+        type: 'dBlock',
+        content: [
+          {
+            type: 'paragraph',
+            content: [{ type: 'text', text: `line ${i}` }],
+          },
+        ],
+      })),
+    });
+
+    const doc = docFrom({
+      type: 'doc',
+      content: [
+        {
+          type: 'dBlock',
+          content: [{ type: 'columns', content: [column(3), column(3)] }],
+        },
+      ],
+    });
+
+    // Six paragraphs total but only three lines tall, so it fits a 4-line
+    // slide. Summing the columns would wrongly split it.
+    const slides = splitDocIntoSlides(doc, { maxLinesPerSlide: 4 });
+    expect(slides).toHaveLength(1);
+  });
+});
+
+describe('isSoloMediaSlide', () => {
+  it('is false for a slide carrying text alongside media', () => {
+    const slide: JSONContent = {
+      type: 'doc',
+      content: [
+        { type: 'dBlock', content: [{ type: 'resizableMedia', attrs: {} }] },
+        {
+          type: 'dBlock',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'caption' }] },
+          ],
+        },
+      ],
+    };
+
+    expect(isSoloMediaSlide(slide)).toBe(false);
+  });
+
+  it('is true for a slide holding only media', () => {
+    const slide: JSONContent = {
+      type: 'doc',
+      content: [
+        { type: 'dBlock', content: [{ type: 'resizableMedia', attrs: {} }] },
+      ],
+    };
+
+    expect(isSoloMediaSlide(slide)).toBe(true);
+  });
+});

--- a/package/utils/doc-to-slides.ts
+++ b/package/utils/doc-to-slides.ts
@@ -511,6 +511,72 @@ export interface BuildSlidesOptions extends DocToSlidesOptions {
 }
 
 /**
+ * The font size in effect for a node's first run of text.
+ *
+ * Sizes arrive two ways: as a `textStyle` mark on the text itself, and as an
+ * attribute on the paragraph. Both are checked, nearest first.
+ */
+const firstFontSize = (node?: JSONContent): string | null => {
+  if (!node) return null;
+
+  const markSize = node.marks?.find(
+    (mark) => mark.type === 'textStyle' && mark.attrs?.fontSize,
+  )?.attrs?.fontSize;
+  if (markSize) return String(markSize);
+
+  if (node.attrs?.fontSize) return String(node.attrs.fontSize);
+
+  for (const child of node.content ?? []) {
+    const found = firstFontSize(child);
+    if (found) return found;
+  }
+
+  return null;
+};
+
+/**
+ * Copies each list item's own text size onto the item.
+ *
+ * A native list marker is sized by its `<li>`, but an explicit size lives on
+ * the mark or paragraph inside it. The marker therefore kept the base size
+ * while its text grew, and the mismatch widened as the presenter font scale
+ * went up. Giving the item the same size lets the marker follow its text.
+ */
+export const matchListMarkersToText = (node: JSONContent): JSONContent => {
+  const content = node.content?.map(matchListMarkersToText);
+
+  if (node.type !== 'listItem') {
+    return content ? { ...node, content } : node;
+  }
+
+  const fontSize = firstFontSize(node);
+
+  return {
+    ...node,
+    ...(content ? { content } : {}),
+    ...(fontSize ? { attrs: { ...node.attrs, fontSize } } : {}),
+  };
+};
+
+/**
+ * Makes explicitly-sized text obey the presenter font scale.
+ *
+ * An inline `font-size` beats any stylesheet rule, so text carrying its own
+ * size ignored the scale entirely while everything around it grew and shrank.
+ * Rewriting the value into the same multiplication the stylesheet uses puts
+ * both under one control.
+ *
+ * Values already expressed as `calc(...)` are left alone: the pattern requires
+ * a digit after the colon, so it cannot wrap its own output twice.
+ */
+export const scaleInlineFontSizes = (html: string): string =>
+  html.replace(
+    /font-size:\s*(-?[\d.]+)(px|rem|em|pt)/gi,
+    (_match, value, unit) =>
+      `font-size: calc(var(--slide-font-scale, 1) * ${value}${unit})`,
+  );
+
+/**
  * Serialises slide documents back to HTML through the editor's own schema.
  *
  * Round-tripping via renderHTML/parseHTML is lossless by construction, so
@@ -540,8 +606,8 @@ const renderSlideDocsToHtml = (
 
   try {
     return slideDocs.map((slideDoc) => {
-      temporaryEditor.commands.setContent(slideDoc);
-      return temporaryEditor.getHTML();
+      temporaryEditor.commands.setContent(matchListMarkersToText(slideDoc));
+      return scaleInlineFontSizes(temporaryEditor.getHTML());
     });
   } finally {
     temporaryEditor.destroy();

--- a/package/utils/doc-to-slides.ts
+++ b/package/utils/doc-to-slides.ts
@@ -1,0 +1,590 @@
+import { JSONContent } from '@tiptap/core';
+import { Editor } from '@tiptap/react';
+import { searchForSecureImageNodeAndEmbedImageContent } from '../extensions/mardown-paste-handler';
+import { IpfsImageFetchPayload } from '../types';
+import { dedupeResolvedExtensions } from './helpers';
+
+/**
+ * Splits a ProseMirror document straight into per-slide documents.
+ *
+ * The existing presentation pipeline goes doc -> HTML -> Markdown -> HTML,
+ * which silently drops every construct Markdown cannot express: multi-column
+ * blocks, paragraph-level font sizes, callouts and other custom nodes. This
+ * module walks the document nodes instead, so a slide is always a real
+ * ProseMirror doc and nothing is lost on the way to the stage.
+ */
+
+export interface DocToSlidesOptions {
+  /** Soft cap on rendered lines before a slide is broken. */
+  maxLinesPerSlide?: number;
+  /** Soft cap on characters before a slide is broken. */
+  maxCharsPerSlide?: number;
+  /** Soft cap on words before a slide is broken. */
+  maxWordsPerSlide?: number;
+  /** Characters that fit on one rendered line, used to estimate wrapping. */
+  charsPerLine?: number;
+  /**
+   * Whether to guess at overflow from character and line counts. Disabled when
+   * the deck will afterwards be measured against the real stage, since counting
+   * characters splits slides that visibly had room to spare.
+   */
+  applyOverflowLimits?: boolean;
+}
+
+/** The slide stage: 1080px wide, 16/9, with `py-[48px]` above and below. */
+const STAGE_WIDTH_PX = 1080;
+const STAGE_HEIGHT_PX = Math.round((STAGE_WIDTH_PX * 9) / 16);
+const STAGE_VERTICAL_PADDING_PX = 96;
+const STAGE_CONTENT_HEIGHT_PX = STAGE_HEIGHT_PX - STAGE_VERTICAL_PADDING_PX;
+
+export const SLIDE_SPLIT_DEFAULTS: Required<DocToSlidesOptions> = {
+  maxLinesPerSlide: 7,
+  maxCharsPerSlide: 1000,
+  maxWordsPerSlide: 250,
+  charsPerLine: 60,
+  applyOverflowLimits: true,
+};
+
+/** Top-level nodes are wrapped in dBlock; unwrap to the node that matters. */
+const getInnerNode = (node: JSONContent): JSONContent =>
+  node?.type === 'dBlock' && node.content?.length ? node.content[0] : node;
+
+const getNodeText = (node?: JSONContent): string => {
+  if (!node) return '';
+  if (node.type === 'text') return node.text ?? '';
+  if (!node.content?.length) return '';
+  return node.content.map(getNodeText).join('');
+};
+
+const countWords = (text: string): number =>
+  text.trim().split(/\s+/).filter(Boolean).length;
+
+const MEDIA_TYPES = new Set([
+  'resizableMedia',
+  'image',
+  'secureImage',
+  'iframe',
+  'twitterEmbed',
+]);
+
+const LIST_TYPES = new Set(['bulletList', 'orderedList', 'taskList']);
+
+const isHeading = (node: JSONContent, level: number): boolean =>
+  node.type === 'heading' && node.attrs?.level === level;
+
+const isMedia = (node: JSONContent): boolean =>
+  MEDIA_TYPES.has(node.type ?? '');
+
+/**
+ * Nodes worth a slide even with no text of their own. Everything else that is
+ * textless is padding — the trailing-node extension keeps an empty paragraph
+ * at the end of every document, which must not become a blank final slide.
+ */
+const RENDERS_WITHOUT_TEXT = new Set([
+  ...MEDIA_TYPES,
+  'table',
+  'horizontalRule',
+  'codeBlock',
+]);
+
+const hasRenderableContent = (node?: JSONContent): boolean => {
+  if (!node) return false;
+  if (RENDERS_WITHOUT_TEXT.has(node.type ?? '')) return true;
+  if (node.type === 'text' && (node.text ?? '').trim().length > 0) return true;
+  return (node.content ?? []).some(hasRenderableContent);
+};
+
+/**
+ * Rough height of a node in "lines". Headings and media are weighted heavier
+ * because the presentation stylesheet renders them much larger than body text.
+ */
+const estimateLines = (node: JSONContent, charsPerLine: number): number => {
+  const inner = getInnerNode(node);
+
+  switch (inner.type) {
+    case 'heading':
+      return inner.attrs?.level === 1 ? 3 : inner.attrs?.level === 2 ? 2 : 1;
+
+    case 'table':
+      return (inner.content?.length ?? 1) + 1;
+
+    case 'codeBlock':
+      return Math.max(1, getNodeText(inner).split('\n').length);
+
+    case 'columns':
+      // Columns sit side by side, so the block is only as tall as its
+      // tallest column rather than the sum of all of them.
+      return Math.max(
+        1,
+        ...(inner.content ?? []).map((column) =>
+          (column.content ?? []).reduce(
+            (sum, child) => sum + estimateLines(child, charsPerLine),
+            0,
+          ),
+        ),
+      );
+
+    default:
+      break;
+  }
+
+  if (isMedia(inner)) return 4;
+
+  if (LIST_TYPES.has(inner.type ?? '')) {
+    return Math.max(1, inner.content?.length ?? 1);
+  }
+
+  const text = getNodeText(inner);
+  return Math.max(1, Math.ceil(text.length / charsPerLine));
+};
+
+interface SlideAccumulator {
+  blocks: JSONContent[];
+  lines: number;
+  chars: number;
+  words: number;
+}
+
+const emptyAccumulator = (): SlideAccumulator => ({
+  blocks: [],
+  lines: 0,
+  chars: 0,
+  words: 0,
+});
+
+const toSlideDoc = (blocks: JSONContent[]): JSONContent => ({
+  type: 'doc',
+  content: blocks,
+});
+
+/**
+ * A slide holding nothing but a single media node is rendered edge to edge
+ * rather than as body content, matching the previous `solo-slide-image`
+ * behaviour of the Markdown pipeline.
+ */
+export const isSoloMediaSlide = (slide: JSONContent): boolean => {
+  const blocks = slide.content ?? [];
+  if (blocks.length !== 1) return false;
+  return isMedia(getInnerNode(blocks[0]));
+};
+
+export const splitDocIntoSlides = (
+  doc: JSONContent,
+  options: DocToSlidesOptions = {},
+): JSONContent[] => {
+  const {
+    maxLinesPerSlide,
+    maxCharsPerSlide,
+    maxWordsPerSlide,
+    charsPerLine,
+    applyOverflowLimits,
+  } = { ...SLIDE_SPLIT_DEFAULTS, ...options };
+
+  const slides: JSONContent[] = [];
+  let current = emptyAccumulator();
+
+  const flush = () => {
+    if (current.blocks.length > 0) {
+      slides.push(toSlideDoc(current.blocks));
+    }
+    current = emptyAccumulator();
+  };
+
+  const push = (block: JSONContent) => {
+    const inner = getInnerNode(block);
+    const text = getNodeText(inner);
+    current.blocks.push(block);
+    current.lines += estimateLines(block, charsPerLine);
+    current.chars += text.length;
+    current.words += countWords(text);
+  };
+
+  const overflows = (block: JSONContent): boolean => {
+    if (current.blocks.length === 0) return false;
+    const inner = getInnerNode(block);
+    const text = getNodeText(inner);
+    return (
+      current.lines + estimateLines(block, charsPerLine) > maxLinesPerSlide ||
+      current.chars + text.length > maxCharsPerSlide ||
+      current.words + countWords(text) > maxWordsPerSlide
+    );
+  };
+
+  (doc.content ?? []).forEach((block) => {
+    const inner = getInnerNode(block);
+
+    // Explicit author-controlled break; the node itself is not rendered.
+    if (inner.type === 'pageBreak') {
+      flush();
+      return;
+    }
+
+    // A heading opens a new slide and sits at the top of it. Whatever follows
+    // packs in underneath for as long as there is room, so a title and its
+    // content stay together instead of the title being stranded alone.
+    if (isHeading(inner, 1) || isHeading(inner, 2)) {
+      flush();
+      push(block);
+      return;
+    }
+
+    // Without measurement the only way to keep a full-bleed image slide from
+    // absorbing the text around it is to promote it eagerly. When the deck is
+    // measured afterwards, real overflow decides instead.
+    if (applyOverflowLimits && isMedia(inner) && current.blocks.length === 0) {
+      slides.push(toSlideDoc([block]));
+      return;
+    }
+
+    if (applyOverflowLimits && overflows(block)) flush();
+    push(block);
+  });
+
+  flush();
+
+  return slides.filter(hasRenderableContent);
+};
+
+/**
+ * Whether the environment performs layout. jsdom parses markup but reports
+ * every height as 0, so measurement has to fall back to the estimates there.
+ */
+const canMeasureLayout = (): boolean => {
+  if (typeof document === 'undefined' || !document.body) return false;
+
+  const probe = document.createElement('div');
+  probe.style.cssText = 'position:absolute;left:-99999px;top:0;width:100px;';
+  probe.innerHTML = '<p style="height:10px">probe</p>';
+  document.body.appendChild(probe);
+
+  const measurable = probe.scrollHeight > 0;
+  probe.remove();
+
+  return measurable;
+};
+
+/**
+ * Hidden stand-in for the slide stage, styled identically so measurements
+ * reflect what the presentation will actually render.
+ */
+const createStageMeasurementHost = (fontScale: number) => {
+  const host = document.createElement('div');
+  host.className = 'presentation-mode';
+  host.setAttribute('aria-hidden', 'true');
+  host.style.cssText = `
+    position: absolute;
+    left: -99999px;
+    top: 0;
+    width: ${STAGE_WIDTH_PX}px;
+    visibility: hidden;
+    pointer-events: none;
+  `;
+  host.style.setProperty('--slide-font-scale', String(fontScale));
+
+  const content = document.createElement('div');
+  content.className = 'ProseMirror';
+  host.appendChild(content);
+  document.body.appendChild(host);
+
+  return { host, content };
+};
+
+/**
+ * Descends through single-child wrappers to the element whose children can
+ * actually be divided. A slide holding one list arrives as
+ * `div > ul > li…`, so the list items are the only useful break points.
+ */
+/**
+ * Breaking these apart would destroy the layout rather than paginate it: the
+ * two halves of a side-by-side block belong on the same slide, and a table
+ * split mid-way loses its header row.
+ */
+const NEVER_DIVIDE_SELECTOR =
+  '[data-type="columns"], [data-type="column"], table';
+
+/** Only list items are safe to paginate between. */
+const DIVISIBLE_TAGS = new Set(['UL', 'OL']);
+
+const findDivisibleElement = (root: Element): Element | null => {
+  let node: Element | null = root;
+
+  while (node) {
+    if (node.matches(NEVER_DIVIDE_SELECTOR)) return null;
+
+    if (DIVISIBLE_TAGS.has(node.tagName) && node.children.length > 1) {
+      return node;
+    }
+
+    if (node.children.length !== 1) return null;
+
+    node = node.firstElementChild;
+  }
+
+  return null;
+};
+
+/** A block whose only real content is a heading. */
+const isHeadingBlock = (element: Element): boolean =>
+  /^H[1-6]$/.test(element.tagName) ||
+  !!element.querySelector('h1, h2, h3, h4, h5, h6');
+
+/** Rebuilds a block keeping only children in `[from, to)`. */
+const withChildRange = (html: string, from: number, to: number): string => {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = html;
+
+  const root = wrapper.firstElementChild;
+  if (!root) return html;
+
+  const target = findDivisibleElement(root);
+  if (!target) return html;
+
+  Array.from(target.children).forEach((child, index) => {
+    if (index < from || index >= to) child.remove();
+  });
+
+  // Keep numbering continuous when an ordered list spans slides.
+  if (target.tagName === 'OL' && from > 0) {
+    const start = Number(target.getAttribute('start') ?? '1');
+    target.setAttribute('start', String(start + from));
+  }
+
+  return wrapper.innerHTML;
+};
+
+/**
+ * Divides one oversized block — typically a long list — by breaking between
+ * its children rather than letting it run off the slide.
+ *
+ * `precedingHtml` is whatever already sits on the slide, so the split accounts
+ * for the space a heading above it has already used.
+ */
+const divideToFit = (
+  html: string,
+  precedingHtml: string,
+  heightOf: (html: string) => number,
+): { head: string; tail: string } | null => {
+  const wrapper = document.createElement('div');
+  wrapper.innerHTML = html;
+
+  const root = wrapper.firstElementChild;
+  if (!root) return null;
+
+  const target = findDivisibleElement(root);
+  if (!target) return null;
+
+  const total = target.children.length;
+  if (total <= 1) return null;
+
+  let take = total - 1;
+  while (
+    take >= 1 &&
+    heightOf(precedingHtml + withChildRange(html, 0, take)) >
+      STAGE_CONTENT_HEIGHT_PX
+  ) {
+    take--;
+  }
+
+  // Not even one child fits alongside what is already there.
+  if (take < 1) return null;
+
+  return {
+    head: withChildRange(html, 0, take),
+    tail: withChildRange(html, take, total),
+  };
+};
+
+/**
+ * Breaks slides that genuinely overflow the stage, and only those.
+ *
+ * Character and line counts are a poor proxy for height: they split slides
+ * that plainly had room left. Measuring the rendered result means a title and
+ * its content stay on one slide whenever they actually fit.
+ */
+export const fitSlidesToStage = (
+  slides: string[],
+  fontScale: number = 1,
+): string[] => {
+  if (slides.length === 0 || !canMeasureLayout()) return slides;
+
+  const { host, content } = createStageMeasurementHost(fontScale);
+
+  const heightOf = (html: string): number => {
+    content.innerHTML = html;
+    return content.scrollHeight;
+  };
+
+  const htmlOf = (elements: Element[]): string =>
+    elements.map((element) => element.outerHTML).join('');
+
+  try {
+    const fitted: string[] = [];
+    const pending = [...slides];
+
+    while (pending.length > 0) {
+      const slide = pending.shift() as string;
+
+      const measuredHeight = heightOf(slide);
+
+      if (measuredHeight <= STAGE_CONTENT_HEIGHT_PX) {
+        fitted.push(slide);
+        continue;
+      }
+
+      const container = document.createElement('div');
+      container.innerHTML = slide;
+      const blocks = Array.from(container.children);
+
+      // One oversized block, typically a long list: break between its
+      // children instead of letting it run off the slide.
+      if (blocks.length <= 1) {
+        const divided = divideToFit(slide, '', heightOf);
+
+        if (divided) {
+          fitted.push(divided.head);
+          pending.unshift(divided.tail);
+        } else {
+          // Genuinely indivisible — a single paragraph or image that is
+          // simply taller than the stage.
+          fitted.push(slide);
+        }
+
+        continue;
+      }
+
+      // Largest run of whole blocks that still fits.
+      let fitCount = blocks.length - 1;
+      while (
+        fitCount > 0 &&
+        heightOf(htmlOf(blocks.slice(0, fitCount))) > STAGE_CONTENT_HEIGHT_PX
+      ) {
+        fitCount--;
+      }
+
+      const headHtml = htmlOf(blocks.slice(0, fitCount));
+      const nextBlock = blocks[fitCount];
+
+      // Whole blocks alone would strand a heading on a slide of its own with
+      // its content pushed to the next one. Carry as much of the following
+      // block as the remaining space allows.
+      const carried = nextBlock
+        ? divideToFit(nextBlock.outerHTML, headHtml, heightOf)
+        : null;
+
+      if (carried) {
+        fitted.push(headHtml + carried.head);
+        pending.unshift(carried.tail + htmlOf(blocks.slice(fitCount + 1)));
+        continue;
+      }
+
+      // The next block cannot be divided — a columns layout, a table, an
+      // image. If everything that fits so far is just headings, keep them with
+      // that block and accept the overflow: a title alone on a slide with its
+      // content on the next one is a worse outcome than a slide that runs a
+      // little long.
+      if (nextBlock && blocks.slice(0, fitCount).every(isHeadingBlock)) {
+        fitted.push(htmlOf(blocks.slice(0, fitCount + 1)));
+        pending.unshift(htmlOf(blocks.slice(fitCount + 1)));
+        continue;
+      }
+
+      // Otherwise emit at least one whole block so the remainder always
+      // shrinks and the loop terminates.
+      const emitCount = Math.max(fitCount, 1);
+      fitted.push(htmlOf(blocks.slice(0, emitCount)));
+      pending.unshift(htmlOf(blocks.slice(emitCount)));
+    }
+
+    return fitted;
+  } finally {
+    host.remove();
+  }
+};
+
+export interface BuildSlidesOptions extends DocToSlidesOptions {
+  /** Current presenter font scale, so measurement matches what is on screen. */
+  fontScale?: number;
+  ipfsImageFetchFn?: (
+    _data: IpfsImageFetchPayload,
+  ) => Promise<{ url: string; file: File }>;
+  fetchV1ImageFn?: (url: string) => Promise<ArrayBuffer | undefined>;
+}
+
+/**
+ * Serialises slide documents back to HTML through the editor's own schema.
+ *
+ * Round-tripping via renderHTML/parseHTML is lossless by construction, so
+ * columns, font sizes and other custom nodes survive — unlike the Markdown
+ * detour this replaces. Slides stay `string[]`, which keeps the preview panel,
+ * PDF export and share links working unchanged.
+ */
+const renderSlideDocsToHtml = (
+  editor: Editor,
+  slideDocs: JSONContent[],
+): string[] => {
+  const temporaryEditor = new Editor({
+    extensions: dedupeResolvedExtensions(
+      editor.extensionManager.extensions,
+    ).filter(
+      (extension) =>
+        ![
+          'collaboration',
+          'aiAutocomplete',
+          // suggestionTracking's filterTransaction rejects every doc-changing
+          // transaction while the source editor is in suggestion mode, which
+          // would silently leave each slide empty.
+          'suggestionTracking',
+        ].includes(extension.name),
+    ),
+  });
+
+  try {
+    return slideDocs.map((slideDoc) => {
+      temporaryEditor.commands.setContent(slideDoc);
+      return temporaryEditor.getHTML();
+    });
+  } finally {
+    temporaryEditor.destroy();
+  }
+};
+
+/**
+ * Builds the presentation deck straight from the editor document.
+ *
+ * Secure images are still inlined first, matching the behaviour of the
+ * Markdown pipeline this supersedes, so IPFS-backed images render on a slide.
+ */
+export const buildSlidesFromDoc = async (
+  editor: Editor,
+  options: BuildSlidesOptions = {},
+): Promise<string[]> => {
+  const {
+    ipfsImageFetchFn,
+    fetchV1ImageFn,
+    fontScale = 1,
+    ...splitOptions
+  } = options;
+
+  const docWithEmbeddedImages =
+    await searchForSecureImageNodeAndEmbedImageContent(
+      editor.state.doc,
+      ipfsImageFetchFn,
+      fetchV1ImageFn,
+      true,
+    );
+
+  // When the stage can be measured, structural breaks are the only ones worth
+  // guessing at — real overflow decides the rest.
+  const measurable = canMeasureLayout();
+
+  const slideDocs = splitDocIntoSlides(docWithEmbeddedImages.toJSON(), {
+    applyOverflowLimits: !measurable,
+    ...splitOptions,
+  });
+
+  if (slideDocs.length === 0) return [];
+
+  const slidesHtml = renderSlideDocsToHtml(editor, slideDocs);
+
+  return measurable ? fitSlidesToStage(slidesHtml, fontScale) : slidesHtml;
+};


### PR DESCRIPTION
## Summary

Slides were derived by serialising the document to Markdown and parsing it back:

```
doc → getHTML() → turndown → Markdown → convertMarkdownToHTML() → HTML → split
```

Everything Markdown cannot express was silently dropped on the way to the stage. `multi-column` and `font-size` extensions already exist in the editor, but no Turndown rule carries them, and `md-to-html.ts` contains the string `column` zero times — so an image beside text was impossible on a slide, and author-set font sizes never arrived.

This builds the deck straight from the ProseMirror document instead. Slides remain `string[]`, rendered back through the editor's own schema, so the preview panel, PDF export and share links are untouched.

Three user-facing additions: **image beside text**, **slide numbers**, and **presenter font scaling**.

---

## Screenshots

### 1. Image beside text (the headline change)

| Before | After |
|---|---|
| <img width="1089" height="623" alt="image" src="https://github.com/user-attachments/assets/404d89b6-2957-4901-bf83-47e032789b23" /> | <img width="1089" height="623" alt="image" src="https://github.com/user-attachments/assets/e6c99562-2e78-49d4-8334-f53839b4bdec" /> |

### 2. Slide numbers and font-size control

<img width="1592" height="993" alt="image" src="https://github.com/user-attachments/assets/cec4bdba-02d9-44fa-b7bb-397979ece3cb" />

### 4. Windowed vs fullscreen parity

<img width="1107" height="614" alt="image" src="https://github.com/user-attachments/assets/126c25fa-cf82-4de1-926a-a22e9a85b1ae" />

<img width="2872" height="1795" alt="image" src="https://github.com/user-attachments/assets/b9ef3ca3-1c29-40e9-95f1-bddbf525cda5" />


---

## What changed

**`package/utils/doc-to-slides.ts`** (new) — splits the document at structural boundaries (page breaks, headings), then decides breaks by **measuring against the real 1080×608 stage** rather than counting characters. The old heuristics (7 lines / 1000 chars / 250 words) split slides that visibly had room to spare. Character counting survives as a fallback for environments without layout.

Fitting rules:
- lists paginate between `<li>` items, with `start` carried over so ordered numbering stays continuous
- **columns and tables are never divided** — breaking a side-by-side layout destroys it rather than paginating it
- a heading is never stranded: if what fits is only headings and the next block is indivisible, they stay together and the slide is allowed to run long. A title alone with its content on the next slide is a worse outcome than a slightly tall slide.

**`presentation-mode.tsx`** — fullscreen used `dangerouslySetInnerHTML` while windowed rendered through the editor, so custom nodes could appear in one and not the other. Both now render through the editor. The wrapper is animated via controls rather than remounted, because `EditorContent` owns the editor's DOM node and re-parenting it per slide is what let the two paths drift apart.

**`editor.css`** — windowed presentation type was set at ~2.2% of stage width while fullscreen already used ~1.6%. Aligned to fullscreen's proportions, and `--slide-font-scale` now threads through both.

**`ddoc-editor.tsx`** — <kbd>Mod</kbd>+<kbd>Alt</kbd>+<kbd>P</kbd> opens the deck.

---

## Bugs found along the way

Not part of the original scope, but worth flagging:

1. **Presenting a ddoc could silently edit it.** The document editor stays mounted behind the presentation overlay and kept DOM focus, so `f`, `+`, `-`, `0`, arrows and space were typed into the document while presenting. Fixed by releasing focus on open and making the presentation editor read-only.
2. **Fullscreen ignored font scaling entirely** — its 14 viewport-relative sizes never referenced the scale variable.
3. **Slide build failures left the loader spinning** with nothing logged. Now surfaced.
4. `processMarkdownContent` in `md-to-slides.ts` (~200 lines) is exported but never imported, and disagrees with the live path (`maxLines` 8 vs 7). Left alone here, but it's dead code.

---

## Behaviour changes reviewers should weigh

- **An H1 no longer produces a bare title slide.** A heading now opens a slide and content packs beneath it; use an explicit page break for a title-only slide.
- **Slides may overflow slightly** rather than stranding a heading (see fitting rules above).
- **Windowed slide typography is substantially smaller** — see screenshot 2.

---

## Testing

`npm run build` passes. 11 unit tests added, covering the structural splitter against the real schema via `getHeadlessExtensions`. Lint unchanged from `main` (8 pre-existing warnings, 0 errors).

**Known coverage gap, stated plainly:** the measurement path is unreachable in unit tests — jsdom parses markup but reports every height as `0`, so `fitSlidesToStage` falls back to heuristics there. Everything in that path was verified by hand in the demo app. The rules most worth protecting (columns never split, headings never stranded, lists paginate) regressed at least once during development and would each have been caught instantly by a browser test. A Playwright test asserting real geometry is the natural follow-up.

---

## Follow-up work, deliberately not in this PR

- **Windowed and fullscreen are still two independent stylesheets.** This PR aligns their numbers; it does not merge them, so they can drift again — and the PDF path is a third set of rules. Four of the bugs above trace to that split. Defining the slide once in stage-proportional units and having fullscreen scale it would remove the class entirely.
- **Font scaling does not re-split the deck.** The scale is read when slides are built, so scaling up afterwards can overflow.
- **Page numbers are not in the PDF export** — `handle-print.ts` is a separate path with its own stylesheet.
- Images inside columns can under-measure if they have not decoded when the slide is measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
