### PR TITLE
fix(dblock-toolbar): guard destroyed editors before view access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.3.7",
+      "version": "4.3.8",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package/extensions/d-block/dblock-toolbar.tsx
+++ b/package/extensions/d-block/dblock-toolbar.tsx
@@ -239,6 +239,7 @@ const getTemplateTarget = (
 ) => {
   if (
     !editor ||
+    editor.isDestroyed ||
     runtimeState.isPreviewMode ||
     runtimeState.isCollaboratorsDoc ||
     // Split View renders the doc read-only on the right — no template picker.
@@ -383,6 +384,11 @@ export const DBlockToolbarProvider = ({
   }, []);
 
   const refreshToolbar = useCallback(() => {
+    if (!editor || editor.isDestroyed) {
+      setActiveDBlock(null);
+      return;
+    }
+
     const currentHandle = activeHandleRef.current;
     currentHandle?.refresh();
 
@@ -395,7 +401,10 @@ export const DBlockToolbarProvider = ({
   }, [editor, setActiveDBlock]);
 
   useEffect(() => {
-    if (!editor) {
+    // The tab-editor cache destroys/recreates editors in pre-paint layout
+    // effects, so this effect can fire with an already-destroyed editor —
+    // whose `view` access throws on tiptap v3.
+    if (!editor || editor.isDestroyed) {
       setActiveDBlock(null);
       return;
     }


### PR DESCRIPTION
The tab-editor cache destroys/recreates editors inside pre-paint layout
effects, so DBlockToolbarProvider's passive effect can fire with an
already-destroyed editor. tiptap v3 replaced the unmounted view with a
Proxy that throws on any access ('The editor view is not available'),
which crashed the viewer surface to the route error boundary on
public-edit share links (/document/{id}#k=) when auto-enter edit swaps
surfaces mid-load.

Bail on editor.isDestroyed in the provider effect and refreshToolbar,
and in getTemplateTarget, which reads editor.view.dom at render time
(same hazard, reachable on empty docs). Bump 4.3.8.