### PR TITLE
fix: externalize react/jsx-runtime (react 19 compat)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/ddoc",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/ddoc",
-      "version": "4.6.0",
+      "version": "4.6.1",
       "dependencies": {
         "@_ueberdosis/prosemirror-tables": "^1.1.3",
         "@aarkue/tiptap-math-extension": "^1.4.0",
@@ -135,7 +135,7 @@
         "@dnd-kit/utilities": ">=3.2.2",
         "@fileverse/crypto": ">=0.0.21",
         "@fileverse/ens": "0.0.4",
-        "@fileverse/ui": "5.3.0",
+        "@fileverse/ui": "5.3.1",
         "framer-motion": ">=11.2.10",
         "frimousse": ">=0.3.0",
         "mermaid": "11.14.0",
@@ -1452,9 +1452,9 @@
       }
     },
     "node_modules/@fileverse/ui": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@fileverse/ui/-/ui-5.3.0.tgz",
-      "integrity": "sha512-pOoxD1PQ3QiS77/e2B9IE2SfYxRCQ9c3eNWq8rnUZEJ/Gxq40eGa5KqO6s51e+YNWKc37HlcASbsVU1M0UcGFg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@fileverse/ui/-/ui-5.3.1.tgz",
+      "integrity": "sha512-0Xpgi2aTx1qnxcoAWW2C6sh/ERg1e5iTOMUa0dw+sh7XPXaPsOCIFDGNcWhsrgz5qx8vTQywhab15SkD8fy6eA==",
       "peer": true,
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "@dnd-kit/utilities": ">=3.2.2",
     "@fileverse/crypto": ">=0.0.21",
     "@fileverse/ens": "0.0.4",
-    "@fileverse/ui": "5.3.0",
+    "@fileverse/ui": "5.3.1",
     "framer-motion": ">=11.2.10",
     "frimousse": ">=0.3.0",
     "mermaid": "11.14.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/ddoc",
   "private": false,
   "description": "DDoc",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,10 @@ export default defineConfig({
           'frimousse',
           'mermaid',
         ].includes(id) ||
+        // Subpath imports (react/jsx-runtime etc.) must stay external too —
+        // inlining them breaks under React 19 (React 18-only internals).
+        id.startsWith('react/') ||
+        id.startsWith('react-dom/') ||
         id === 'yjs' ||
         id.startsWith('yjs/') ||
         id.startsWith('@fileverse/crypto') ||


### PR DESCRIPTION
Same issue as fileverse-ui#93: the vite external predicate matched 'react' exactly, so react subpath imports (jsx-runtime / jsx-dev-runtime) were inlined into the dist chunks with React-18-only internals access (ReactCurrentOwner/ReactCurrentDispatcher via __SECRET_INTERNALS). Under react 19 importing those chunks crashes in dev/test.

Fix: also externalize react/* and react-dom/* subpaths. Bumps 4.6.1. Verified dist chunks have zero internals references.

⚠ Merge order: fileverse-ui#93 must publish 5.3.1 first; a follow-up commit here bumps the exact ui peer pin before merge (same dance as last time).