### PR TITLE
feat: storage-agnostic image props (imageUploadFn / imageFetchFn)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,5 +48,15 @@ export {
 } from './package/sync-local/session-tools';
 
 export type { CommentMutationMeta, SuggestionType } from './package/types';
+export type {
+  ImageUploadFn,
+  ImageFetchFn,
+  StorageImageUploadResponse,
+  StorageImageFetchPayload,
+} from './package/types';
+export {
+  resolveImageUploadFn,
+  resolveImageFetchFn,
+} from './package/utils/storage-adapter';
 export type { IComment } from './package/extensions/comment/comment.ts';
 export type { FontDescriptor } from './package/types';

--- a/package/ddoc-editor.tsx
+++ b/package/ddoc-editor.tsx
@@ -1,6 +1,10 @@
 import { EditorContent, isTextSelection } from '@tiptap/react';
 import { EditorBubbleMenu } from './components/editor-bubble-menu/editor-bubble-menu';
 import { DdocProps } from './types';
+import {
+  resolveImageFetchFn,
+  resolveImageUploadFn,
+} from './utils/storage-adapter';
 import type { CollaborationProps } from './sync-local/types';
 
 // A LIVE collaboration session (peers/presence — what users know as "real-time
@@ -93,7 +97,8 @@ const DdocEditor = forwardRef(
       handleCommentButtonClick,
       showCommentButton,
       ensResolutionUrl,
-      ipfsImageUploadFn,
+      imageUploadFn,
+      ipfsImageUploadFn: ipfsImageUploadFnProp,
       disableBottomToolbar,
       onError,
       setCharacterCount,
@@ -164,7 +169,8 @@ const DdocEditor = forwardRef(
       onCopyHeadingLink,
       tabConfig,
       footerHeight,
-      ipfsImageFetchFn,
+      imageFetchFn,
+      ipfsImageFetchFn: ipfsImageFetchFnProp,
       fetchV1ImageFn,
       activeModel,
       maxTokens,
@@ -176,6 +182,16 @@ const DdocEditor = forwardRef(
     }: DdocProps,
     ref,
   ) => {
+    // Resolve the storage-agnostic image fns (preferred) against the
+    // deprecated ipfs-prefixed ones; internals keep the legacy interface.
+    const ipfsImageUploadFn = useMemo(
+      () => resolveImageUploadFn(imageUploadFn, ipfsImageUploadFnProp),
+      [imageUploadFn, ipfsImageUploadFnProp],
+    );
+    const ipfsImageFetchFn = useMemo(
+      () => resolveImageFetchFn(imageFetchFn, ipfsImageFetchFnProp),
+      [imageFetchFn, ipfsImageFetchFnProp],
+    );
     const { isFocusMode, toggleFocusMode } = useFocusMode({
       isFocusMode: isFocusModeProp,
       onFocusModeChange,

--- a/package/preview-ddoc-editor.tsx
+++ b/package/preview-ddoc-editor.tsx
@@ -9,9 +9,14 @@ import {
   forwardRef,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from 'react';
+import {
+  resolveImageFetchFn,
+  resolveImageUploadFn,
+} from './utils/storage-adapter';
 import { Button, Tag, TagType, TagInput, cn, Skeleton } from '@fileverse/ui';
 import { useMediaQuery, useOnClickOutside } from 'usehooks-ts';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -33,7 +38,8 @@ const PreviewDdocEditorContent = forwardRef(
       onTextSelection,
       onCommentInteraction,
       ensResolutionUrl,
-      ipfsImageUploadFn,
+      imageUploadFn,
+      ipfsImageUploadFn: ipfsImageUploadFnProp,
       onError,
       setCharacterCount,
       setWordCount,
@@ -43,7 +49,8 @@ const PreviewDdocEditorContent = forwardRef(
       setSelectedTags,
       className,
       unFocused,
-      ipfsImageFetchFn,
+      imageFetchFn,
+      ipfsImageFetchFn: ipfsImageFetchFnProp,
       fetchV1ImageFn,
       contentClassName,
       isLoading,
@@ -57,6 +64,16 @@ const PreviewDdocEditorContent = forwardRef(
     }: DdocProps & { contentClassName?: string; isLoading?: boolean },
     ref,
   ) => {
+    // Resolve the storage-agnostic image fns (preferred) against the
+    // deprecated ipfs-prefixed ones; internals keep the legacy interface.
+    const ipfsImageUploadFn = useMemo(
+      () => resolveImageUploadFn(imageUploadFn, ipfsImageUploadFnProp),
+      [imageUploadFn, ipfsImageUploadFnProp],
+    );
+    const ipfsImageFetchFn = useMemo(
+      () => resolveImageFetchFn(imageFetchFn, ipfsImageFetchFnProp),
+      [imageFetchFn, ipfsImageFetchFnProp],
+    );
     const [isHiddenTagsVisible, setIsHiddenTagsVisible] = useState(false);
     const tagsContainerRef = useRef(null);
 

--- a/package/types.ts
+++ b/package/types.ts
@@ -182,6 +182,15 @@ export interface DdocProps extends CommentAccountProps {
   };
   tabSectionContainer?: HTMLElement;
   isCollabDocumentPublished?: boolean;
+  /**
+   * Storage-agnostic image fetch function. Receives the stored location of an
+   * encrypted image (`url` + `contentRef`, e.g. an IPFS gateway URL + CID or a
+   * Swarm URL + reference) along with its decryption parameters, and returns
+   * the decrypted image. Preferred over the deprecated `ipfsImageFetchFn`;
+   * when both are provided, `imageFetchFn` wins.
+   */
+  imageFetchFn?: ImageFetchFn;
+  /** @deprecated Use the storage-agnostic `imageFetchFn` instead. */
   ipfsImageFetchFn?: (
     _data: IpfsImageFetchPayload,
   ) => Promise<{ url: string; file: File }>;
@@ -236,6 +245,15 @@ export interface DdocProps extends CommentAccountProps {
   isPreviewMode: boolean;
   viewerMode?: 'suggest' | 'view-only';
   ensResolutionUrl?: string;
+  /**
+   * Storage-agnostic image upload function. Encrypts and stores the file on
+   * the host's storage backend (IPFS, Swarm, ...) and returns its location
+   * (`url` + `contentRef`) plus the decryption parameters. Preferred over the
+   * deprecated `ipfsImageUploadFn`; when both are provided, `imageUploadFn`
+   * wins.
+   */
+  imageUploadFn?: ImageUploadFn;
+  /** @deprecated Use the storage-agnostic `imageUploadFn` instead. */
   ipfsImageUploadFn?: (file: File) => Promise<IpfsImageUploadResponse>;
   enableIndexeddbSync?: boolean;
   ddocId?: string;
@@ -335,6 +353,38 @@ export interface IUser {
 }
 
 export { type IComment };
+/**
+ * Storage-agnostic result of an image upload. The editor treats both fields
+ * as opaque: `url` is a fetchable location of the encrypted blob (e.g. an
+ * IPFS gateway URL or a Swarm `/bytes` URL) and `contentRef` is the backend's
+ * content address (IPFS CID, Swarm reference, ...). Both are stored in the
+ * document and handed back verbatim to `imageFetchFn`.
+ */
+export interface StorageImageUploadResponse {
+  encryptionKey: string;
+  nonce: string;
+  authTag: string;
+  url: string;
+  contentRef: string;
+}
+/**
+ * Storage-agnostic payload handed to `imageFetchFn`: the `url`/`contentRef`
+ * returned by `imageUploadFn` at upload time, plus the parameters needed to
+ * decrypt the blob.
+ */
+export interface StorageImageFetchPayload {
+  encryptionKey: string;
+  nonce: string;
+  authTag: string;
+  mimeType: string;
+  url: string;
+  contentRef: string;
+}
+export type ImageUploadFn = (file: File) => Promise<StorageImageUploadResponse>;
+export type ImageFetchFn = (
+  _data: StorageImageFetchPayload,
+) => Promise<{ url: string; file: File }>;
+/** @deprecated Use the storage-agnostic {@link StorageImageUploadResponse} instead. */
 export interface IpfsImageUploadResponse {
   encryptionKey: string;
   nonce: string;
@@ -342,6 +392,7 @@ export interface IpfsImageUploadResponse {
   ipfsHash: string;
   authTag: string;
 }
+/** @deprecated Use the storage-agnostic {@link StorageImageFetchPayload} instead. */
 export interface IpfsImageFetchPayload {
   encryptionKey: string;
   nonce: string;

--- a/package/utils/storage-adapter.test.ts
+++ b/package/utils/storage-adapter.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveImageFetchFn, resolveImageUploadFn } from './storage-adapter';
+import type {
+  ImageFetchFn,
+  ImageUploadFn,
+  IpfsImageFetchPayload,
+  IpfsImageUploadResponse,
+} from '../types';
+
+const file = new File(['pixels'], 'photo.png', { type: 'image/png' });
+
+const agnosticUploadResult = {
+  encryptionKey: 'key',
+  nonce: 'nonce',
+  authTag: 'tag',
+  url: 'https://gateway.example/content/abc123',
+  contentRef: 'abc123',
+};
+
+const legacyFetchPayload: IpfsImageFetchPayload = {
+  encryptionKey: 'key',
+  nonce: 'nonce',
+  authTag: 'tag',
+  mimeType: 'image/png',
+  ipfsUrl: 'https://gateway.example/content/abc123',
+  ipfsHash: 'abc123',
+};
+
+describe('resolveImageUploadFn', () => {
+  it('maps a storage-agnostic response onto the legacy field names', async () => {
+    const imageUploadFn: ImageUploadFn = vi
+      .fn()
+      .mockResolvedValue(agnosticUploadResult);
+
+    const resolved = resolveImageUploadFn(imageUploadFn, undefined);
+    const response = await resolved!(file);
+
+    expect(imageUploadFn).toHaveBeenCalledWith(file);
+    expect(response).toEqual({
+      encryptionKey: 'key',
+      nonce: 'nonce',
+      authTag: 'tag',
+      ipfsUrl: agnosticUploadResult.url,
+      ipfsHash: agnosticUploadResult.contentRef,
+    });
+  });
+
+  it('prefers the storage-agnostic fn when both are given', async () => {
+    const imageUploadFn: ImageUploadFn = vi
+      .fn()
+      .mockResolvedValue(agnosticUploadResult);
+    const ipfsImageUploadFn = vi.fn();
+
+    const resolved = resolveImageUploadFn(imageUploadFn, ipfsImageUploadFn);
+    await resolved!(file);
+
+    expect(imageUploadFn).toHaveBeenCalledOnce();
+    expect(ipfsImageUploadFn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the deprecated fn, unwrapped', () => {
+    const ipfsImageUploadFn = vi.fn<[File], Promise<IpfsImageUploadResponse>>();
+    expect(resolveImageUploadFn(undefined, ipfsImageUploadFn)).toBe(
+      ipfsImageUploadFn,
+    );
+  });
+
+  it('resolves to undefined when neither is given', () => {
+    expect(resolveImageUploadFn(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveImageFetchFn', () => {
+  it('maps the legacy payload onto the storage-agnostic field names', async () => {
+    const fetched = { url: 'blob:decrypted', file };
+    const imageFetchFn: ImageFetchFn = vi.fn().mockResolvedValue(fetched);
+
+    const resolved = resolveImageFetchFn(imageFetchFn, undefined);
+    await expect(resolved!(legacyFetchPayload)).resolves.toBe(fetched);
+
+    expect(imageFetchFn).toHaveBeenCalledWith({
+      encryptionKey: 'key',
+      nonce: 'nonce',
+      authTag: 'tag',
+      mimeType: 'image/png',
+      url: legacyFetchPayload.ipfsUrl,
+      contentRef: legacyFetchPayload.ipfsHash,
+    });
+  });
+
+  it('prefers the storage-agnostic fn when both are given', async () => {
+    const imageFetchFn: ImageFetchFn = vi
+      .fn()
+      .mockResolvedValue({ url: 'blob:decrypted', file });
+    const ipfsImageFetchFn = vi.fn();
+
+    const resolved = resolveImageFetchFn(imageFetchFn, ipfsImageFetchFn);
+    await resolved!(legacyFetchPayload);
+
+    expect(imageFetchFn).toHaveBeenCalledOnce();
+    expect(ipfsImageFetchFn).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the deprecated fn, unwrapped', () => {
+    const ipfsImageFetchFn = vi.fn<
+      [IpfsImageFetchPayload],
+      Promise<{ url: string; file: File }>
+    >();
+    expect(resolveImageFetchFn(undefined, ipfsImageFetchFn)).toBe(
+      ipfsImageFetchFn,
+    );
+  });
+
+  it('resolves to undefined when neither is given', () => {
+    expect(resolveImageFetchFn(undefined, undefined)).toBeUndefined();
+  });
+});

--- a/package/utils/storage-adapter.ts
+++ b/package/utils/storage-adapter.ts
@@ -1,0 +1,70 @@
+import {
+  ImageFetchFn,
+  ImageUploadFn,
+  IpfsImageFetchPayload,
+  IpfsImageUploadResponse,
+} from '../types';
+
+/**
+ * Boundary adapters between the storage-agnostic public props
+ * (`imageUploadFn` / `imageFetchFn`) and the IPFS-shaped interface the editor
+ * internals still use. Internals are untouched: a storage-agnostic host
+ * function is wrapped here, at the prop boundary, so that downstream code
+ * keeps seeing the legacy `ipfsUrl` / `ipfsHash` field names regardless of
+ * which backend the host actually stores on.
+ */
+
+type LegacyImageUploadFn = (file: File) => Promise<IpfsImageUploadResponse>;
+type LegacyImageFetchFn = (
+  _data: IpfsImageFetchPayload,
+) => Promise<{ url: string; file: File }>;
+
+/**
+ * Resolve the upload function to use internally. The storage-agnostic
+ * `imageUploadFn` wins over the deprecated `ipfsImageUploadFn`; its response
+ * is mapped onto the legacy field names (`url` → `ipfsUrl`,
+ * `contentRef` → `ipfsHash`).
+ */
+export const resolveImageUploadFn = (
+  imageUploadFn?: ImageUploadFn,
+  ipfsImageUploadFn?: LegacyImageUploadFn,
+): LegacyImageUploadFn | undefined => {
+  if (imageUploadFn) {
+    return async (file: File) => {
+      const { encryptionKey, nonce, authTag, url, contentRef } =
+        await imageUploadFn(file);
+      return {
+        encryptionKey,
+        nonce,
+        authTag,
+        ipfsUrl: url,
+        ipfsHash: contentRef,
+      };
+    };
+  }
+  return ipfsImageUploadFn;
+};
+
+/**
+ * Resolve the fetch function to use internally. The storage-agnostic
+ * `imageFetchFn` wins over the deprecated `ipfsImageFetchFn`; the legacy
+ * payload built by the internals is mapped onto the agnostic field names
+ * (`ipfsUrl` → `url`, `ipfsHash` → `contentRef`).
+ */
+export const resolveImageFetchFn = (
+  imageFetchFn?: ImageFetchFn,
+  ipfsImageFetchFn?: LegacyImageFetchFn,
+): LegacyImageFetchFn | undefined => {
+  if (imageFetchFn) {
+    return ({ encryptionKey, nonce, authTag, mimeType, ipfsUrl, ipfsHash }) =>
+      imageFetchFn({
+        encryptionKey,
+        nonce,
+        authTag,
+        mimeType,
+        url: ipfsUrl,
+        contentRef: ipfsHash,
+      });
+  }
+  return ipfsImageFetchFn;
+};


### PR DESCRIPTION
## What

Adds backend-neutral image-storage props and deprecates the IPFS-named ones:

- `imageUploadFn(file) → { url, contentRef, encryptionKey, nonce, authTag }`
- `imageFetchFn({ url, contentRef, ... }) → { url, file }`

`ipfsImageUploadFn` / `ipfsImageFetchFn` keep working unchanged and are
marked `@deprecated`. When both are passed, the storage-agnostic one wins.

## Why

dDoc is built to be embedded, but the image-storage boundary names one
backend: a host storing images anywhere else must pass its uploader through
`ipfs*`-named props and return its locations in `ipfsUrl` / `ipfsHash`
fields. The new props are the same contract with honest names — `url` (where
to fetch) and `contentRef` (the content address or key) — so any backend fits
without misleading field names, IPFS included.

## How

The change is confined to the prop boundary. A 70-line adapter
(`package/utils/storage-adapter.ts`) resolves the new props against the
deprecated ones and maps field names (`url` ↔ `ipfsUrl`, `contentRef` ↔
`ipfsHash`); editor internals are untouched and keep seeing the legacy
interface. The resolvers are exported for headless usage, so
`useHeadlessEditor` callers with a storage-agnostic fn can adapt it in one
call. Renaming internals can follow as a purely mechanical PR if wanted.

## Compatibility & testing

- No behavior change unless the new props are passed; no new dependencies.
- Unit tests cover both resolvers: precedence, field mapping both
  directions, and pass-through of the deprecated fns.
- `tsc`, `eslint`, and the full vitest suite pass.
